### PR TITLE
Some cleanliness changes.

### DIFF
--- a/Sources/NIOTransportServices/StateManagedChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedChannel.swift
@@ -240,9 +240,7 @@ extension StateManagedChannel {
             return
         }
 
-        if let promise = promise {
-            promise.succeed(result: ())
-        }
+        promise?.succeed(result: ())
         self.pipeline.fireChannelActive()
         self.readIfNeeded0()
     }

--- a/Sources/NIOTransportServices/StateManagedChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedChannel.swift
@@ -46,12 +46,10 @@ internal enum ChannelState<ActiveSubstate: ActiveChannelSubstate> {
     }
 
     fileprivate mutating func beginActivating() throws {
-        switch self {
-        case .registered:
-            self = .activating
-        case .idle, .activating, .active, .inactive:
+        guard case .registered = self else {
             throw NIOTSErrors.InvalidChannelStateTransition()
         }
+        self = .activating
     }
 
     fileprivate mutating func becomeActive() throws {


### PR DESCRIPTION
Use `DispatchWorkItem.cancel()` for cancellation. Make `ChannelState.beginActivating()` use the same methodology as all the others.

### Motivation:

These things *irked* me. Especially the comment about Dispatch not providing for cancellation. Tsk, Tsk.

### Modifications:

`NIOTSEventLoop.scheduleTask` will now create a cancellable `DispatchWorkItem` to be scheduled, and will use `workItem.cancel()` in the cancellation task for the returned `Scheduled` instance.

The state change methods in `ChannelState` for some reason contained two different methods of checking & handling the current state. I made them more uniform because reasons. *\*twitch\**

### Result:

I will feel a lot happier.