### PR TITLE
better diagnostics if unsupported ChannelOption set

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -305,7 +305,7 @@ extension NIOTSConnectionChannel: Channel {
                 self.pipeline.fireChannelWritabilityChanged()
             }
         default:
-            fatalError("option \(option) not supported")
+            fatalError("option \(type(of: option)).\(option) not supported")
         }
     }
 
@@ -346,7 +346,7 @@ extension NIOTSConnectionChannel: Channel {
         case _ as WriteBufferWaterMarkOption:
             return self.backpressureManager.waterMarks as! T.OptionType
         default:
-            fatalError("option \(option) not supported")
+            fatalError("option \(type(of: option)).\(option) not supported")
         }
     }
 }


### PR DESCRIPTION
Motivation:

If the user sets an unsupported ChannelOption we should give the best
diagnostics possible.

Modifications:

Add the ChannelOption type to the error message that it's unsupported.

Result:

Happier users
