### PR TITLE
Remove invalid assertion.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -650,7 +650,6 @@ extension NIOTSConnectionChannel {
         guard self.isActive else {
             // If we're already not active, we aren't going to process any of this: it's likely the result of an extra
             // read somewhere along the line.
-            assert(content == nil)
             return
         }
 


### PR DESCRIPTION
Motivation:

It is possible to receive the dataReceived callback after we've called
cancel, mostly because there may be such a block in place in the queue
before that cancel call fires. We should tolerate that.

Modifications:

Removed the invalid assertion.

Result:

Fewer failures.
