### PR TITLE
Make Channel.isActive thread-safe.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -176,6 +176,9 @@ internal final class NIOTSConnectionChannel {
     /// The state of this connection channel.
     internal var state: ChannelState<ActiveSubstate> = .idle
 
+    /// The active state, used for safely reporting the channel state across threads.
+    internal var isActive0: Atomic<Bool> = Atomic(value: false)
+
     /// The kinds of channel activation this channel supports
     internal let supportedActivationType: ActivationType = .connect
 

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -16,6 +16,7 @@
 import Foundation
 import NIO
 import NIOFoundationCompat
+import NIOConcurrencyHelpers
 import Dispatch
 import Network
 
@@ -59,6 +60,9 @@ internal final class NIOTSListenerChannel {
 
     /// The kinds of channel activation this channel supports
     internal let supportedActivationType: ActivationType = .bind
+
+    /// The active state, used for safely reporting the channel state across threads.
+    internal var isActive0: Atomic<Bool> = Atomic(value: false)
 
     /// Whether a call to NWListener.receive has been made, but the completion
     /// handler has not yet been invoked.


### PR DESCRIPTION
Motivation:

Sadly I overlooked the fact that Channel.isActive is supposed to be
safe to call from multiple threads: the implementation here was not.

Modifications:

Store the active state into an Atomic.

Result:

It will be thread-safe to ask if a channel is active.
