### PR TITLE
use to NIO 2 (from master branch) and Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -17,13 +17,16 @@ import PackageDescription
 
 let package = Package(
     name: "swift-nio-transport-services",
+    platforms: [
+       .macOS(.v10_14), .iOS(.v12), .tvOS(.v12),
+    ],
     products: [
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
         .executable(name: "NIOTSHTTPClient", targets: ["NIOTSHTTPClient"]),
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.11.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", .branch("master")),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/README.md
+++ b/README.md
@@ -16,24 +16,21 @@ Network.framework is Apple's reference implementation of the [proposed post-sock
 
 ## How to Use?
 
-Today, the easiest way to use SwiftNIO Transport Services is through CocoaPods:
+Today, the easiest way to use SwiftNIO Transport Services in an iOS project is through CocoaPods:
 
     pod 'SwiftNIO'
     pod 'SwiftNIOTransportServices'
 
-You can also use the Swift Package Manager, however Network.framework is only available on macOS 10.14+, iOS 12+, and tvOS 12+. This does not match the current minimum deployment target for Swift Package Manager, so building this repository with Swift Package Manager requires that you pass custom build flags, e.g:
+You can also use the Swift Package Manager:
 
 ```
-swift build -Xswiftc -target -Xswiftc x86_64-apple-macosx10.14
+swift build
 ```
 
-Alternatively, if you want to use Xcode to build this repository, you can use the following xcconfig:
+and add the project as a sub-project by dragging it into your iOS project and adding the frameworks (such as `NIO.framework`) in 'Build Phases' -> 'Link Binary Libraries'.
 
-```
-MACOSX_DEPLOYMENT_TARGET = 10.14
-```
+Do note however that Network.framework requires macOS 10.14+, iOS 12+, or tvOS 12+.
 
-For support in iOS or tvOS, change the targets as necessary.
 
 ## Versioning
 

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -210,7 +210,7 @@ internal final class NIOTSConnectionChannel {
                   tcpOptions: NWProtocolTCP.Options,
                   tlsOptions: NWProtocolTLS.Options?) {
         self.tsEventLoop = eventLoop
-        self.closePromise = eventLoop.newPromise()
+        self.closePromise = eventLoop.makePromise()
         self.parent = parent
         self.connectionQueue = eventLoop.channelQueue(label: "nio.nioTransportServices.connectionchannel", qos: qos)
         self.tcpOptions = tcpOptions
@@ -273,7 +273,7 @@ extension NIOTSConnectionChannel: Channel {
 
     public func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T : ChannelOption {
         if eventLoop.inEventLoop {
-            let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+            let promise: EventLoopPromise<Void> = eventLoop.makePromise()
             executeAndComplete(promise) { try setOption0(option: option, value: value) }
             return promise.futureResult
         } else {
@@ -325,7 +325,7 @@ extension NIOTSConnectionChannel: Channel {
 
     public func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T : ChannelOption {
         if eventLoop.inEventLoop {
-            let promise: EventLoopPromise<T.OptionType> = eventLoop.newPromise()
+            let promise: EventLoopPromise<T.OptionType> = eventLoop.makePromise()
             executeAndComplete(promise) { try getOption0(option: option) }
             return promise.futureResult
         } else {

--- a/Sources/NIOTransportServices/NIOTSEventLoop.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoop.swift
@@ -104,7 +104,7 @@ internal class NIOTSEventLoop: QoSEventLoop {
     }
 
     public func scheduleTask<T>(in time: TimeAmount, qos: DispatchQoS, _ task: @escaping () throws -> T) -> Scheduled<T> {
-        let p: EventLoopPromise<T> = self.newPromise()
+        let p: EventLoopPromise<T> = self.makePromise()
 
         guard self.state != .closed else {
             p.fail(error: EventLoopError.shutdown)
@@ -153,7 +153,7 @@ extension NIOTSEventLoop {
 
 extension NIOTSEventLoop {
     internal func closeGently() -> EventLoopFuture<Void> {
-        let p: EventLoopPromise<Void> = self.newPromise()
+        let p: EventLoopPromise<Void> = self.makePromise()
         self.taskQueue.async {
             guard self.open else {
                 p.fail(error: EventLoopError.shutdown)
@@ -181,7 +181,7 @@ extension NIOTSEventLoop {
             // event loop it will be forbidden from doing so.
             let completionFuture = EventLoopFuture<Void>.andAll(futures, eventLoop: self)
             completionFuture.cascade(promise: p)
-            completionFuture.whenComplete {
+            completionFuture.whenComplete { (_: Result<Void, Error>) in
                 self.state = .closed
             }
         }

--- a/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
@@ -68,7 +68,7 @@ public final class NIOTSEventLoopGroup: EventLoopGroup {
             g.enter()
             loop.closeGently().mapIfError { err in
                 q.sync { error = err }
-            }.whenComplete {
+            }.whenComplete { (_: Result<Void, Error>) in
                 g.leave()
             }
         }
@@ -76,5 +76,9 @@ public final class NIOTSEventLoopGroup: EventLoopGroup {
         g.notify(queue: q) {
             callback(error)
         }
+    }
+
+    public func makeIterator() -> EventLoopIterator {
+        return EventLoopIterator(self.eventLoops)
     }
 }

--- a/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
+++ b/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
@@ -18,7 +18,7 @@ import Foundation
 import NIO
 import Network
 
-internal extension IPv4Address {
+extension IPv4Address {
     /// Create an `IPv4Address` object from a `sockaddr_in`.
     internal init(fromSockAddr sockAddr: sockaddr_in) {
         var localAddr = sockAddr
@@ -30,7 +30,7 @@ internal extension IPv4Address {
     }
 }
 
-internal extension IPv6Address {
+extension IPv6Address {
     internal init(fromSockAddr sockAddr: sockaddr_in6) {
         var localAddr = sockAddr
 
@@ -44,7 +44,7 @@ internal extension IPv6Address {
     }
 }
 
-internal extension NWEndpoint {
+extension NWEndpoint {
     /// Create an `NWEndpoint` value from a NIO `SocketAddress`.
     internal init(fromSocketAddress socketAddress: SocketAddress) {
         switch socketAddress {
@@ -57,11 +57,11 @@ internal extension NWEndpoint {
             self = NWEndpoint.unix(path: path)
         case .v4(let v4Addr):
             let v4Address = IPv4Address(fromSockAddr: v4Addr.address)
-            let port = NWEndpoint.Port(rawValue: socketAddress.port!)!
+            let port = NWEndpoint.Port(rawValue: UInt16(socketAddress.port!))!
             self = NWEndpoint.hostPort(host: .ipv4(v4Address), port: port)
         case .v6(let v6Addr):
             let v6Address = IPv6Address(fromSockAddr: v6Addr.address)
-            let port = NWEndpoint.Port(rawValue: socketAddress.port!)!
+            let port = NWEndpoint.Port(rawValue: UInt16(socketAddress.port!))!
             self = NWEndpoint.hostPort(host: .ipv6(v6Address), port: port)
         }
     }
@@ -69,7 +69,7 @@ internal extension NWEndpoint {
 
 // TODO: We'll want to get rid of this when we support returning NWEndpoint directly from
 // the various address-handling functions.
-internal extension SocketAddress {
+extension SocketAddress {
     internal init(fromNWEndpoint endpoint: NWEndpoint) throws {
         switch endpoint {
         case .hostPort(.ipv4(let host), let port):
@@ -96,8 +96,10 @@ internal extension SocketAddress {
             self = try .init(unixDomainSocketPath: path)
         case .service:
             preconditionFailure("Cannot represent service addresses in SocketAddress")
-        case .hostPort(.name, _):
-            preconditionFailure("Cannot represent host by name only as SocketAddress")
+        case .hostPort(_, _):
+            preconditionFailure("Cannot represent unknown host in SocketAddress")
+        @unknown default:
+            preconditionFailure("cannot create SocketAddress from unknown representation")
         }
     }
 }

--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -52,7 +52,7 @@ final class ReadExpecter: ChannelInboundHandler {
     }
 
     func handlerAdded(ctx: ChannelHandlerContext) {
-        self.readPromise = ctx.eventLoop.newPromise()
+        self.readPromise = ctx.eventLoop.makePromise()
     }
 
     func handlerRemoved(ctx: ChannelHandlerContext) {
@@ -248,7 +248,7 @@ class NIOTSEndToEndTests: XCTestCase {
                     closeFutures.append(channel.closeFuture)
                 }
                 closeFutureGroup.leave()
-                return channel.eventLoop.newSucceededFuture(result: ())
+                return channel.eventLoop.makeSucceededFuture(result: ())
             }
             .bind(host: "localhost", port: 0).wait()
         defer {
@@ -279,7 +279,7 @@ class NIOTSEndToEndTests: XCTestCase {
     }
 
     func testAgreeOnRemoteLocalAddresses() throws {
-        let serverSideConnectionPromise: EventLoopPromise<Channel> = self.group.next().newPromise()
+        let serverSideConnectionPromise: EventLoopPromise<Channel> = self.group.next().makePromise()
         let listener = try NIOTSListenerBootstrap(group: self.group)
             .childChannelInitializer { channel in
                 serverSideConnectionPromise.succeed(result: channel)
@@ -303,7 +303,7 @@ class NIOTSEndToEndTests: XCTestCase {
     }
 
     func testHalfClosureSupported() throws {
-        let halfClosedPromise: EventLoopPromise<Void> = self.group.next().newPromise()
+        let halfClosedPromise: EventLoopPromise<Void> = self.group.next().makePromise()
         let listener = try NIOTSListenerBootstrap(group: self.group)
             .childChannelInitializer { channel in
                 channel.pipeline.add(handler: EchoHandler()).then { _ in

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -51,7 +51,7 @@ class NIOTSEventLoopTest: XCTestCase {
             firstTask.cancel()
         }
         let thirdTask = loop.scheduleTask(in: .milliseconds(50)) { }
-        firstTask.futureResult.whenComplete {
+        firstTask.futureResult.whenComplete { (_: Result<Void, Error>) in
             let newNow = DispatchTime.now()
             XCTAssertLessThan(newNow.uptimeNanoseconds - now.uptimeNanoseconds,
                               300 * 1000 * 1000)

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -56,7 +56,7 @@ class NIOTSListenerChannelTests: XCTestCase {
 
     func testBindingToSocketAddressTraversesPipeline() throws {
         let bindRecordingHandler = BindRecordingHandler()
-        let target = try SocketAddress.newAddressResolving(host: "localhost", port: 0)
+        let target = try SocketAddress.makeAddressResolvingHost("localhost", port: 0)
         let bindBootstrap = NIOTSListenerBootstrap(group: self.group)
             .serverChannelInitializer { channel in channel.pipeline.add(handler: bindRecordingHandler)}
 
@@ -88,7 +88,7 @@ class NIOTSListenerChannelTests: XCTestCase {
         }
 
         try self.group.next().submit {
-            XCTAssertEqual(bindRecordingHandler.bindTargets, [try SocketAddress.newAddressResolving(host: "localhost", port: 0)])
+            XCTAssertEqual(bindRecordingHandler.bindTargets, [try SocketAddress.makeAddressResolvingHost("localhost", port: 0)])
             XCTAssertEqual(bindRecordingHandler.endpointTargets, [])
         }.wait()
     }
@@ -143,7 +143,7 @@ class NIOTSListenerChannelTests: XCTestCase {
         struct MyError: Error { }
 
         let listenerFuture = NIOTSListenerBootstrap(group: self.group)
-            .serverChannelInitializer { channel in channel.eventLoop.newFailedFuture(error: MyError()) }
+            .serverChannelInitializer { channel in channel.eventLoop.makeFailedFuture(error: MyError()) }
             .bind(host: "localhost", port: 0)
 
         do {
@@ -160,8 +160,8 @@ class NIOTSListenerChannelTests: XCTestCase {
     func testCanSafelyInvokeChannelsAcrossThreads() throws {
         // This is a test that aims to trigger TSAN violations.
         let childGroup = NIOTSEventLoopGroup(loopCount: 2)
-        let childChannelPromise: EventLoopPromise<Channel> = childGroup.next().newPromise()
-        let activePromise: EventLoopPromise<Void> = childGroup.next().newPromise()
+        let childChannelPromise: EventLoopPromise<Channel> = childGroup.next().makePromise()
+        let activePromise: EventLoopPromise<Void> = childGroup.next().makePromise()
 
         let listener = try NIOTSListenerBootstrap(group: self.group, childGroup: childGroup)
             .childChannelInitializer { channel in


### PR DESCRIPTION
Motivation:

SwiftPM from Swift 5.0 brings targets that only support certain systems
which is really handy for this package as it only support macOS 10.14+
and iOS/tvOS 12+

Modifications:

- made use of the Swift 5.0 manifests which can have restrictions on the
  supported platforms
- adapted to NIO 2

Result:

- better development story
- using the latest & greatest
