### PR TITLE
Don't transition to .registered unless registration succeeds.

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -593,4 +593,19 @@ class NIOTSConnectionChannelTests: XCTestCase {
 
         XCTAssertNoThrow(try channel.close().wait())
     }
+
+    func testConnectingChannelsOnShutdownEventLoopsFails() throws {
+        let temporaryGroup = NIOTSEventLoopGroup()
+        XCTAssertNoThrow(try temporaryGroup.syncShutdownGracefully())
+
+        let bootstrap = NIOTSConnectionBootstrap(group: temporaryGroup)
+
+        do {
+            _ = try bootstrap.connect(host: "localhost", port: 12345).wait()
+        } catch EventLoopError.shutdown {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -184,4 +184,19 @@ class NIOTSListenerChannelTests: XCTestCase {
         XCTAssertNoThrow(try childChannel.close().wait())
         XCTAssertNoThrow(try channel.closeFuture.wait())
     }
+
+    func testBindingChannelsOnShutdownEventLoopsFails() throws {
+        let temporaryGroup = NIOTSEventLoopGroup()
+        XCTAssertNoThrow(try temporaryGroup.syncShutdownGracefully())
+
+        let bootstrap = NIOTSListenerBootstrap(group: temporaryGroup)
+
+        do {
+            _ = try bootstrap.bind(host: "localhost", port: 0).wait()
+        } catch EventLoopError.shutdown {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

In some cases, such as when an event loop has been shutdown, channel
registration may fail. In these cases, we would incorrectly attempt to
deregister the channel, which would fail (and in debug builds, assert).
Really, we shouldn't transition into .registered until we know that we have,
in fact, registered.

However, we need to be cautious: we don't want to register unless we
believe we're in an acceptable state to register.

Modifications:

Updated the state enum to perform the registration at the correct
part of the state change function.

Result:

Harder to crash in debug mode
