### PR TITLE
port to latest NIO 2 APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,12 +30,12 @@ let package = Package(
     ],
     targets: [
         .target(name: "NIOTransportServices",
-            dependencies: ["NIO", "NIOFoundationCompat", "NIOConcurrencyHelpers", "NIOTLS"]),
+            dependencies: ["NIO", "NIOFoundationCompat", "NIOConcurrencyHelpers", "NIOTLS", "_NIO1APIShims"]),
         .target(name: "NIOTSHTTPClient",
-            dependencies: ["NIO", "NIOTransportServices", "NIOHTTP1"]),
+            dependencies: ["NIO", "NIOTransportServices", "NIOHTTP1", "_NIO1APIShims"]),
         .target(name: "NIOTSHTTPServer",
-            dependencies: ["NIO", "NIOTransportServices", "NIOHTTP1"]),
+            dependencies: ["NIO", "NIOTransportServices", "NIOHTTP1", "_NIO1APIShims"]),
         .testTarget(name: "NIOTransportServicesTests",
-            dependencies: ["NIO", "NIOTransportServices"]),
+            dependencies: ["NIO", "NIOTransportServices", "_NIO1APIShims"]),
     ]
 )

--- a/Sources/NIOTransportServices/NIOTSEventLoop.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoop.swift
@@ -166,7 +166,7 @@ extension NIOTSEventLoop {
             // We need to tell all currently-registered channels to close.
             let futures: [EventLoopFuture<Void>] = self.registeredChannels.map { _, channel in
                 channel.close(promise: nil)
-                return channel.closeFuture.thenIfErrorThrowing { error in
+                return channel.closeFuture.flatMapErrorThrowing { error in
                     if let error = error as? ChannelError, error == .alreadyClosed {
                         return ()
                     } else {

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -31,15 +31,15 @@ private extension Channel {
     /// Asserts that a given socket option has a default value, that its value can be changed to a new value, and that it can then be
     /// switched back.
     func assertOptionRoundTrips(option: SocketOption, initialValue: SocketOptionValue, testAlternativeValue: SocketOptionValue) -> EventLoopFuture<Void> {
-        return self.getSocketOption(option).then { actualInitialValue in
+        return self.getSocketOption(option).flatMap { actualInitialValue in
             XCTAssertEqual(actualInitialValue, initialValue)
             return self.setSocketOption(option, to: testAlternativeValue)
-        }.then {
+        }.flatMap {
             self.getSocketOption(option)
-        }.then { actualNewValue in
+        }.flatMap { actualNewValue in
             XCTAssertEqual(actualNewValue, testAlternativeValue)
             return self.setSocketOption(option, to: initialValue)
-        }.then {
+        }.flatMap {
             self.getSocketOption(option)
         }.map { returnedToValue in
             XCTAssertEqual(returnedToValue, initialValue)


### PR DESCRIPTION
Motivation:

Compiling code is good so let's make it compile again with the latest
NIO APIs.

Modifications:
- made NIOTS use `_NIO1APIShims`
- clicked 'Fix All' a couple of times to adjust the API

Result:
Code compiles again