### PR TITLE
Support setting enablePeerToPeer.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -32,8 +32,23 @@ public enum NIOTSWaitForActivityOption: ChannelOption {
 }
 
 
+/// `NIOTSEnablePeerToPeerOption` controls whether the `Channel` will advertise services using peer-to-peer
+/// connectivity. Setting this to true is the equivalent of setting `NWParameters.enablePeerToPeer` to
+/// `true`. By default this option is set to `false`.
+///
+/// This option must be set on the bootstrap: setting it after the channel is initialized will have no effect.
+public enum NIOTSEnablePeerToPeerOption: ChannelOption {
+    public typealias AssociatedValueType = ()
+    public typealias OptionType = Bool
+
+    case const(())
+}
+
+
 /// Options that can be set explicitly and only on bootstraps provided by `NIOTransportServices`.
 public struct NIOTSChannelOptions {
     /// - seealso: `NIOTSWaitForActivityOption`.
     public static let waitForActivity = NIOTSWaitForActivityOption.const(())
+
+    public static let enablePeerToPeer = NIOTSEnablePeerToPeerOption.const(())
 }

--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -573,6 +573,30 @@ class NIOTSConnectionChannelTests: XCTestCase {
         XCTAssertNoThrow(try conn.close().wait())
     }
 
+    func testCanObserveValueOfEnablePeerToPeer() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connectFuture = NIOTSConnectionBootstrap(group: self.group)
+            .channelInitializer { channel in
+                return channel.getOption(option: NIOTSChannelOptions.enablePeerToPeer).map { value in
+                    XCTAssertFalse(value)
+                }.then {
+                    channel.setOption(option: NIOTSChannelOptions.enablePeerToPeer, value: true)
+                }.then {
+                    channel.getOption(option: NIOTSChannelOptions.enablePeerToPeer)
+                }.map { value in
+                    XCTAssertTrue(value)
+                }
+            }.connect(to: listener.localAddress!)
+
+        let conn = try connectFuture.wait()
+        XCTAssertNoThrow(try conn.close().wait())
+    }
+
     func testCanSafelyInvokeActiveFromMultipleThreads() throws {
         // This test exists to trigger TSAN violations if we screw things up.
         let listener = try NIOTSListenerBootstrap(group: self.group)

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -184,4 +184,23 @@ class NIOTSListenerChannelTests: XCTestCase {
         XCTAssertNoThrow(try childChannel.close().wait())
         XCTAssertNoThrow(try channel.closeFuture.wait())
     }
+
+    func testCanObserveValueOfEnablePeerToPeer() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .serverChannelInitializer { channel in
+                return channel.getOption(option: NIOTSChannelOptions.enablePeerToPeer).map { value in
+                    XCTAssertFalse(value)
+                }.then {
+                    channel.setOption(option: NIOTSChannelOptions.enablePeerToPeer, value: true)
+                }.then {
+                    channel.getOption(option: NIOTSChannelOptions.enablePeerToPeer)
+                }.map { value in
+                    XCTAssertTrue(value)
+                }
+            }
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

Some users may wish to use peer-to-peer networking with bonjour.

Modifications:

Expose peer-to-peer networking via a new channel option.

Result:

Users will be able to use peer-to-peer networking