### PR TITLE
Support setting enablePeerToPeer. (#22)

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -32,8 +32,23 @@ public enum NIOTSWaitForActivityOption: ChannelOption {
 }
 
 
+/// `NIOTSEnablePeerToPeerOption` controls whether the `Channel` will advertise services using peer-to-peer
+/// connectivity. Setting this to true is the equivalent of setting `NWParameters.enablePeerToPeer` to
+/// `true`. By default this option is set to `false`.
+///
+/// This option must be set on the bootstrap: setting it after the channel is initialized will have no effect.
+public enum NIOTSEnablePeerToPeerOption: ChannelOption {
+    public typealias AssociatedValueType = ()
+    public typealias OptionType = Bool
+
+    case const(())
+}
+
+
 /// Options that can be set explicitly and only on bootstraps provided by `NIOTransportServices`.
 public struct NIOTSChannelOptions {
     /// - seealso: `NIOTSWaitForActivityOption`.
     public static let waitForActivity = NIOTSWaitForActivityOption.const(())
+
+    public static let enablePeerToPeer = NIOTSEnablePeerToPeerOption.const(())
 }

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -77,6 +77,9 @@ internal final class NIOTSListenerChannel {
     /// The value of SO_REUSEPORT.
     private var reusePort = false
 
+    /// Whether to enable peer-to-peer connectivity when using Bonjour services.
+    private var enablePeerToPeer = false
+
     /// Create a `NIOTSListenerChannel` on a given `NIOTSEventLoop`.
     ///
     /// Note that `NIOTSListenerChannel` objects cannot be created on arbitrary loops types.
@@ -166,6 +169,8 @@ extension NIOTSListenerChannel: Channel {
             default:
                 try self.tcpOptions.applyChannelOption(option: optionValue, value: value as! SocketOptionValue)
             }
+        case is NIOTSEnablePeerToPeerOption:
+            self.enablePeerToPeer = value as! NIOTSEnablePeerToPeerOption.OptionType
         default:
             fatalError("option \(option) not supported")
         }
@@ -201,6 +206,8 @@ extension NIOTSListenerChannel: Channel {
             default:
                 return try self.tcpOptions.valueFor(socketOption: optionValue) as! T.OptionType
             }
+        case is NIOTSEnablePeerToPeerOption:
+            return self.enablePeerToPeer as! T.OptionType
         default:
             fatalError("option \(option) not supported")
         }
@@ -276,6 +283,8 @@ extension NIOTSListenerChannel: StateManagedChannel {
         // Network.framework munges REUSEADDR and REUSEPORT together, so we turn this on if we need
         // either.
         parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort
+
+        parameters.includePeerToPeer = self.enablePeerToPeer
 
         let listener: NWListener
         do {

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -199,4 +199,23 @@ class NIOTSListenerChannelTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    func testCanObserveValueOfEnablePeerToPeer() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .serverChannelInitializer { channel in
+                return channel.getOption(option: NIOTSChannelOptions.enablePeerToPeer).map { value in
+                    XCTAssertFalse(value)
+                }.then {
+                    channel.setOption(option: NIOTSChannelOptions.enablePeerToPeer, value: true)
+                }.then {
+                    channel.getOption(option: NIOTSChannelOptions.enablePeerToPeer)
+                }.map { value in
+                    XCTAssertTrue(value)
+                }
+            }
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

Some users may wish to use peer-to-peer networking with bonjour.

Modifications:

Expose peer-to-peer networking via a new channel option.

Result:

Users will be able to use peer-to-peer networking

(cherry picked from commit e9c1e41fd1a4e4c5908322c49d1db38795c13a12)
