### PR TITLE
update to latest NIO 2

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -24,11 +24,10 @@ import NIO
 /// transitioning into the `failed` state, causing immediate connection failure.
 ///
 /// This option is only valid with `NIOTSConnectionBootstrap`.
-public enum NIOTSWaitForActivityOption: ChannelOption {
-    public typealias AssociatedValueType = ()
-    public typealias OptionType = Bool
+public struct NIOTSWaitForActivityOption: ChannelOption, Equatable {
+    public typealias Value = Bool
 
-    case const(())
+    public init() {}
 }
 
 
@@ -37,18 +36,17 @@ public enum NIOTSWaitForActivityOption: ChannelOption {
 /// `true`. By default this option is set to `false`.
 ///
 /// This option must be set on the bootstrap: setting it after the channel is initialized will have no effect.
-public enum NIOTSEnablePeerToPeerOption: ChannelOption {
-    public typealias AssociatedValueType = ()
-    public typealias OptionType = Bool
+public struct NIOTSEnablePeerToPeerOption: ChannelOption, Equatable {
+    public typealias Value = Bool
 
-    case const(())
+    public init() {}
 }
 
 
 /// Options that can be set explicitly and only on bootstraps provided by `NIOTransportServices`.
 public struct NIOTSChannelOptions {
     /// - seealso: `NIOTSWaitForActivityOption`.
-    public static let waitForActivity = NIOTSWaitForActivityOption.const(())
+    public static let waitForActivity = NIOTSWaitForActivityOption()
 
-    public static let enablePeerToPeer = NIOTSEnablePeerToPeerOption.const(())
+    public static let enablePeerToPeer = NIOTSEnablePeerToPeerOption()
 }

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -52,7 +52,7 @@ public final class NIOTSConnectionBootstrap {
     /// - parameters:
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
-    public func channelOption<T: ChannelOption>(_ option: T, value: T.OptionType) -> Self {
+    public func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
         channelOptions.put(key: option, value: value)
         return self
     }
@@ -178,10 +178,10 @@ internal struct ChannelOptionStorage {
     private var storage: [(Any, (Any, (Channel) -> (Any, Any) -> EventLoopFuture<Void>))] = []
 
     mutating func put<K: ChannelOption>(key: K,
-                                        value newValue: K.OptionType) {
+                                        value newValue: K.Value) {
         func applier(_ t: Channel) -> (Any, Any) -> EventLoopFuture<Void> {
             return { (x, y) in
-                return t.setOption(option: x as! K, value: y as! K.OptionType)
+                return t.setOption(x as! K, value: y as! K.Value)
             }
         }
         var hasSet = false

--- a/Sources/NIOTransportServices/NIOTSErrors.swift
+++ b/Sources/NIOTransportServices/NIOTSErrors.swift
@@ -33,7 +33,7 @@ public enum NIOTSErrors {
     /// `UnsupportedSocketOption` is thrown when an attempt is made to configure a socket option that
     /// is not supported by Network.framework.
     public struct UnsupportedSocketOption: NIOTSError {
-        public let optionValue: SocketOption.AssociatedValueType
+        public let optionValue: SocketOption
 
         public static func ==(lhs: UnsupportedSocketOption, rhs: UnsupportedSocketOption) -> Bool {
             return lhs.optionValue == rhs.optionValue

--- a/Sources/NIOTransportServices/TCPOptions+SocketChannelOption.swift
+++ b/Sources/NIOTransportServices/TCPOptions+SocketChannelOption.swift
@@ -20,7 +20,7 @@ import Network
 internal extension NWProtocolTCP.Options {
     /// Apply a given channel `SocketOption` to this protocol options state.
     func applyChannelOption(option: SocketOption, value: SocketOptionValue) throws {
-        switch option.value {
+        switch (option.level, option.name) {
         case (IPPROTO_TCP, TCP_NODELAY):
             self.noDelay = value != 0
         case (IPPROTO_TCP, TCP_NOPUSH):
@@ -46,13 +46,13 @@ internal extension NWProtocolTCP.Options {
         case (SOL_SOCKET, SO_KEEPALIVE):
             self.enableKeepalive = value != 0
         default:
-            throw NIOTSErrors.UnsupportedSocketOption(optionValue: option.value)
+            throw NIOTSErrors.UnsupportedSocketOption(optionValue: option)
         }
     }
 
     /// Obtain the given `SocketOption` value for this protocol options state.
     func valueFor(socketOption option: SocketOption) throws -> SocketOptionValue {
-        switch option.value {
+        switch (option.level, option.name) {
         case (IPPROTO_TCP, TCP_NODELAY):
             return self.noDelay ? 1 : 0
         case (IPPROTO_TCP, TCP_NOPUSH):
@@ -78,7 +78,7 @@ internal extension NWProtocolTCP.Options {
         case (SOL_SOCKET, SO_KEEPALIVE):
             return self.enableKeepalive ? 1 : 0
         default:
-            throw NIOTSErrors.UnsupportedSocketOption(optionValue: option.value)
+            throw NIOTSErrors.UnsupportedSocketOption(optionValue: option)
         }
     }
 }

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
@@ -142,8 +142,8 @@ class NIOTSSocketOptionTests: XCTestCase {
         do {
             try self.options.applyChannelOption(option: option, value: 0)
         } catch let err as NIOTSErrors.UnsupportedSocketOption {
-            XCTAssertEqual(err.optionValue.0, Int32.max)
-            XCTAssertEqual(err.optionValue.1, Int32.max)
+            XCTAssertEqual(err.optionValue.level, Int32.max)
+            XCTAssertEqual(err.optionValue.name, Int32.max)
         } catch {
             XCTFail("Unexpected error \(error)")
         }
@@ -155,8 +155,8 @@ class NIOTSSocketOptionTests: XCTestCase {
         do {
             _ = try self.options.valueFor(socketOption: option)
         } catch let err as NIOTSErrors.UnsupportedSocketOption {
-            XCTAssertEqual(err.optionValue.0, Int32.max)
-            XCTAssertEqual(err.optionValue.1, Int32.max)
+            XCTAssertEqual(err.optionValue.level, Int32.max)
+            XCTAssertEqual(err.optionValue.name, Int32.max)
         } catch {
             XCTFail("Unexpected error \(error)")
         }

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -21,11 +21,11 @@ import Network
 
 private extension Channel {
     private func getSocketOption(_ option: SocketOption) -> EventLoopFuture<SocketOptionValue> {
-        return self.getOption(option: ChannelOptions.socket(option.value.0, option.value.1))
+        return self.getOption(option)
     }
 
     private func setSocketOption(_ option: SocketOption, to value: SocketOptionValue) -> EventLoopFuture<Void> {
-        return self.setOption(option: ChannelOptions.socket(option.value.0, option.value.1), value: value)
+        return self.setOption(option, value: value)
     }
 
     /// Asserts that a given socket option has a default value, that its value can be changed to a new value, and that it can then be


### PR DESCRIPTION
Motivation:

Code should compile and have the latest NIO 2 API.

Modifications:

- rename `ctx` to `context`
- apply all fixits

Result:

compiles again