### PR TITLE
make NIOTS compile on Linux

### DIFF
--- a/Sources/NIOTSHTTPClient/main.swift
+++ b/Sources/NIOTSHTTPClient/main.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import NIO
 import NIOTransportServices
 import NIOHTTP1
@@ -69,3 +71,4 @@ let channel = try! NIOTSConnectionBootstrap(group: group)
 
 // Wait for the request to complete
 try! channel.closeFuture.wait()
+#endif

--- a/Sources/NIOTSHTTPServer/main.swift
+++ b/Sources/NIOTSHTTPServer/main.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import NIO
 import NIOTransportServices
 import NIOHTTP1
@@ -48,3 +50,4 @@ print("Server listening on \(channel.localAddress!)")
 
 // Wait for the request to complete
 try! channel.closeFuture.wait()
+#endif

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -13,10 +13,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import NIO
 import Dispatch
 import Network
-
 
 public final class NIOTSConnectionBootstrap {
     private let group: NIOTSEventLoopGroup
@@ -219,3 +220,4 @@ internal struct ChannelOptionStorage {
         return applyPromise.futureResult
     }
 }
+#endif

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Foundation
 import NIO
 import NIOConcurrencyHelpers
@@ -807,3 +809,4 @@ fileprivate extension ChannelState where ActiveSubstate == NIOTSConnectionChanne
         }
     }
 }
+#endif

--- a/Sources/NIOTransportServices/NIOTSEventLoop.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoop.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Foundation
 import NIO
 import Dispatch
@@ -215,3 +217,4 @@ extension NIOTSEventLoop {
         assert(oldChannel != nil)
     }
 }
+#endif

--- a/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Foundation
 import NIO
 import NIOConcurrencyHelpers
@@ -82,3 +84,4 @@ public final class NIOTSEventLoopGroup: EventLoopGroup {
         return EventLoopIterator(self.eventLoops)
     }
 }
+#endif

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import NIO
 import Dispatch
 import Network
@@ -308,3 +310,4 @@ private class AcceptHandler: ChannelInboundHandler {
         }
     }
 }
+#endif

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Foundation
 import NIO
 import NIOFoundationCompat
@@ -421,3 +423,4 @@ extension NIOTSListenerChannel {
         self.becomeActive0(promise: promise)
     }
 }
+#endif

--- a/Sources/NIOTransportServices/NIOTSNetworkEvents.swift
+++ b/Sources/NIOTransportServices/NIOTSNetworkEvents.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Network
 import NIO
 
@@ -66,3 +68,4 @@ public enum NIOTSNetworkEvents {
         public let endpoint: NWEndpoint
     }
 }
+#endif

--- a/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
+++ b/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Darwin
 import Foundation
 import NIO
@@ -121,3 +123,4 @@ internal extension SocketAddress {
         }
     }
 }
+#endif

--- a/Sources/NIOTransportServices/StateManagedChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedChannel.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Foundation
 import NIO
 import NIOFoundationCompat
@@ -266,3 +268,4 @@ extension StateManagedChannel {
         self.beginActivating0(to: endpoint, promise: promise)
     }
 }
+#endif

--- a/Sources/NIOTransportServices/TCPOptions+SocketChannelOption.swift
+++ b/Sources/NIOTransportServices/TCPOptions+SocketChannelOption.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import Foundation
 import NIO
 import Network
@@ -82,3 +84,4 @@ internal extension NWProtocolTCP.Options {
         }
     }
 }
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import XCTest
 import Network
 import NIO
@@ -638,3 +640,4 @@ class NIOTSConnectionChannelTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import XCTest
 import NIO
 import NIOTransportServices
@@ -470,3 +472,4 @@ class NIOTSEndToEndTests: XCTestCase {
         XCTAssertNoThrow(try completeFuture.wait())
     }
 }
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import XCTest
 import NIO
 import NIOTransportServices
@@ -87,3 +89,4 @@ class NIOTSEventLoopTest: XCTestCase {
         try EventLoopFuture<Void>.andAllComplete([firstTask.futureResult, secondTask.futureResult], on: firstLoop).wait()
     }
 }
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import XCTest
 import Network
 import NIO
@@ -219,3 +221,4 @@ class NIOTSListenerChannelTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import XCTest
 import NIO
 import Network
@@ -162,3 +164,4 @@ class NIOTSSocketOptionTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if canImport(Network)
 import XCTest
 import NIO
 import Network
@@ -121,4 +123,4 @@ class NIOTSSocketOptionsOnChannelTests: XCTestCase {
         try self.assertChannelOptionAfterCreation(option: SocketOption(level: SOL_SOCKET, name: SO_KEEPALIVE), initialValue: 0, testAlternativeValue: 1)
     }
 }
-
+#endif


### PR DESCRIPTION
Motivation:

NIOTS will not work on Linux but we can at least make it not fail
compilation when compiled on Linux. That way consumers of the API can
depend on NIOTS but make sure they only use NIOTS when wrapped in a
`#if canImport(Network)` block.

Modification:

Guard everything by `#if canImport(Network)`

Result:

- This package will now build on Linux (without providing any useful code).
- fixes #21 
