### PR TITLE
Correctly avoid branch dependency.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .branch("2.0.0-convergence.1")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.1"),
     ],
     targets: [
         .target(name: "NIOTransportServices",


### PR DESCRIPTION
Motivation:

When entering convergence we incorrectly specified a branch dependency
for something that is actually a tag.

Modifications:

- Remove branch dependency, use from: instead.

Result:

Users can use this repo!
