### PR TITLE
Remove unnecessary traps.

### DIFF
--- a/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
+++ b/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
@@ -97,11 +97,11 @@ extension SocketAddress {
         case .unix(let path):
             self = try .init(unixDomainSocketPath: path)
         case .service:
-            preconditionFailure("Cannot represent service addresses in SocketAddress")
+            throw NIOTSErrors.UnableToResolveEndpoint()
         case .hostPort(_, _):
-            preconditionFailure("Cannot represent unknown host in SocketAddress")
+            throw NIOTSErrors.UnableToResolveEndpoint()
         @unknown default:
-            preconditionFailure("cannot create SocketAddress from unknown representation")
+            throw NIOTSErrors.UnableToResolveEndpoint()
         }
     }
 }


### PR DESCRIPTION
Motivation:

At least in some cases it's possible to have a local or remote address
that we cannot represent in a SocketAddress. In the face of that, we were
unnecessarily crashing. Crashes should probably be avoided there.

Modifications:

- Replace the crashes with throws.

Result:

Fewer crashes, more nils.
