### PR TITLE
Allow setting multiple options of the same type.

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -122,5 +122,27 @@ class NIOTSSocketOptionsOnChannelTests: XCTestCase {
     func testSO_KEEPALIVE() throws {
         try self.assertChannelOptionAfterCreation(option: SocketOption(level: SOL_SOCKET, name: SO_KEEPALIVE), initialValue: 0, testAlternativeValue: 1)
     }
+
+    func testMultipleSocketOptions() throws {
+        let listener = try NIOTSListenerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR), value: 1)
+            .serverChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+            .bind(host: "127.0.0.1", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+        let connector = try NIOTSConnectionBootstrap(group: group)
+            .channelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR), value: 1)
+            .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+            .connect(to: listener.localAddress!).wait()
+        defer {
+            XCTAssertNoThrow(try connector.close().wait())
+        }
+
+        XCTAssertNoThrow(XCTAssertEqual(1, try listener.getOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR)).wait()))
+        XCTAssertNoThrow(XCTAssertEqual(1, try listener.getOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY)).wait()))
+        XCTAssertNoThrow(XCTAssertEqual(1, try connector.getOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR)).wait()))
+        XCTAssertNoThrow(XCTAssertEqual(1, try connector.getOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY)).wait()))
+    }
 }
 #endif


### PR DESCRIPTION
Motivation:

While we fixed a bug in SwiftNIO about setting multiple options of the same type in
apple/swift-nio#597, we never brought a fix for that issue forward. We did aim to resolve
this in SwiftNIO 2.0 by providing ChannelOptions.Storage, but unfortunately we forgot to
make the initializer for that type public (see apple/swift-nio#988). While SwiftNIO core
has to get its ducks in a row, users of this library should still be able to set more than
one socket option, in my humble opinion.

Modifications:

- Ported over ChannelOptions.Storage until apple/swift-nio#988 is fixed.
- Transitioned our code to use it.
- Tested it works.

Result:

Users can set multiple channel options.