### PR TITLE
Pass Channels down pipeline not NWConnection

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -22,6 +22,7 @@ import NIOTransportServices
 import Foundation
 
 
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 final class ConnectRecordingHandler: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
@@ -71,6 +72,7 @@ final class WritabilityChangedHandler: ChannelInboundHandler {
 }
 
 
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 final class DisableWaitingAfterConnect: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
@@ -103,6 +105,7 @@ final class PromiseOnActiveHandler: ChannelInboundHandler {
 }
 
 
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 class NIOTSConnectionChannelTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 

--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -164,7 +164,7 @@ extension ByteBufferAllocator {
     }
 }
 
-
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 class NIOTSEndToEndTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -20,6 +20,8 @@ import NIO
 import NIOConcurrencyHelpers
 import NIOTransportServices
 
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 class NIOTSEventLoopTest: XCTestCase {
     func testIsInEventLoopWorks() throws {
         let group = NIOTSEventLoopGroup()

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
@@ -21,6 +21,7 @@ import Network
 @testable import NIOTransportServices
 
 
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 class NIOTSSocketOptionTests: XCTestCase {
     private var options: NWProtocolTCP.Options!
 

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -49,7 +49,7 @@ private extension Channel {
     }
 }
 
-
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
 class NIOTSSocketOptionsOnChannelTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 


### PR DESCRIPTION
Motivation:

The expectation is that server channels use Channel as their data type,
but the initial data type in NIOTSListenerChannel was actually
NWConnection. This is unnecessary and it makes it hard to interop
between NIOTS and NIO.

Modifications:

- Initialize the NIOTSConnectionChannel in the NIOTSListenerChannel
instead of in AcceptHandler.
- Added some missing @available annotations in the tests.

Result:

More consistency
Resolves #44.