### PR TITLE
Enable TCP_NODELAY by default.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -35,6 +35,8 @@ public final class NIOTSConnectionBootstrap {
     ///     - group: The `NIOTSEventLoopGroup` to use.
     public init(group: NIOTSEventLoopGroup) {
         self.group = group
+
+        self.channelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
     /// Initialize the connected `NIOTSConnectionChannel` with `initializer`. The most common task in initializer is to add

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -38,6 +38,9 @@ public final class NIOTSListenerBootstrap {
     ///     - group: The `EventLoopGroup` to use for the `ServerSocketChannel`.
     public convenience init(group: NIOTSEventLoopGroup) {
         self.init(group: group, childGroup: group)
+
+        self.serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+        self.childChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
     /// Create a `NIOTSListenerBootstrap`.
@@ -49,6 +52,9 @@ public final class NIOTSListenerBootstrap {
     public init(group: NIOTSEventLoopGroup, childGroup: NIOTSEventLoopGroup) {
         self.group = group
         self.childGroup = childGroup
+        
+        self.serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+        self.childChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
     /// Initialize the `NIOTSListenerChannel` with `initializer`. The most common task in initializer is to add

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -76,7 +76,7 @@ class NIOTSSocketOptionsOnChannelTests: XCTestCase {
     }
 
     func testNODELAY() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_NODELAY), initialValue: 0, testAlternativeValue: 1)
+        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_NODELAY), initialValue: 1, testAlternativeValue: 0)
     }
 
     func testNOPUSH() throws {


### PR DESCRIPTION
Motivation:

Networking software like SwiftNIO that always has explicit flushes
usually does not benefit from having TCP_NODELAY switched off. The
benefits of having it turned on are usually quite substantial and yet we
forced our users for the longest time to enable it manually.

Quite a bit of engineering time has been lost finding performance
problems and it turns out switching TCP_NODELAY on solves them
magically.

Netty has made the switch to TCP_NODELAY on by default, SwiftNIO should
follow. This patch is the equivalent of apple/swift-nio#1020.

Modifications:

Enable TCP_NODELAY by default.

Result:

If the user forgot to enable TCP_NODELAY, their software should now be
faster.
