### PR TITLE
Handle .url endpoint in switches over endpoint.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -301,6 +301,8 @@ extension NIOTSListenerChannel: StateManagedChannel {
             parameters.requiredLocalEndpoint = target
         case .service(_, _, _, let interface):
             parameters.requiredInterface = interface
+        case .url:
+            break
         @unknown default:
             ()
         }

--- a/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
+++ b/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
@@ -100,9 +100,7 @@ extension SocketAddress {
             self = .init(addr, host: host.debugDescription)
         case .unix(let path):
             self = try .init(unixDomainSocketPath: path)
-        case .service:
-            throw NIOTSErrors.UnableToResolveEndpoint()
-        case .hostPort(_, _):
+        case .service, .hostPort, .url:
             throw NIOTSErrors.UnableToResolveEndpoint()
         @unknown default:
             throw NIOTSErrors.UnableToResolveEndpoint()


### PR DESCRIPTION
Motivation:

macOS Catalina brings a .url endpoint to Network.framework, which is
currently causing build warnings. We should tolerate it and silence
those warnings.

Modifications:

Do the right thing when we receive a .url endpoint.

Result:

No build warnings.
