### PR TITLE
Lower EventLoopGroup requirements for creating bootstraps

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -21,7 +21,7 @@ import Network
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 public final class NIOTSConnectionBootstrap {
-    private let group: NIOTSEventLoopGroup
+    private let group: EventLoopGroup
     private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     private var connectTimeout: TimeAmount = TimeAmount.seconds(10)
     private var channelOptions = ChannelOptionsStorage()
@@ -29,11 +29,11 @@ public final class NIOTSConnectionBootstrap {
     private var tcpOptions: NWProtocolTCP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
 
-    /// Create a `NIOTSConnectionBootstrap` on the `NIOTSEventLoopGroup` `group`.
+    /// Create a `NIOTSConnectionBootstrap` on the `EventLoopGroup` `group`.
     ///
     /// - parameters:
-    ///     - group: The `NIOTSEventLoopGroup` to use.
-    public init(group: NIOTSEventLoopGroup) {
+    ///     - group: The `EventLoopGroup` to use.
+    public init(group: EventLoopGroup) {
         self.group = group
 
         self.channelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -31,12 +31,28 @@ public final class NIOTSConnectionBootstrap {
 
     /// Create a `NIOTSConnectionBootstrap` on the `EventLoopGroup` `group`.
     ///
+    /// This initializer only exists to be more in-line with the NIO core bootstraps, in that they
+    /// may be constructed with an `EventLoopGroup` and by extenstion an `EventLoop`. As such an
+    /// existing `NIOTSEventLoop` may be used to initialize this bootstrap. Where possible the
+    /// initializers accepting `NIOTSEventLoopGroup` should be used instead to avoid the wrong
+    /// type being used.
+    ///
+    /// Note that the "real" solution is described in https://github.com/apple/swift-nio/issues/674.
+    ///
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use.
     public init(group: EventLoopGroup) {
         self.group = group
 
         self.channelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+    }
+
+    /// Create a `NIOTSConnectionBootstrap` on the `NIOTSEventLoopGroup` `group`.
+    ///
+    /// - parameters:
+    ///     - group: The `NIOTSEventLoopGroup` to use.
+    public convenience init(group: NIOTSEventLoopGroup) {
+      self.init(group: group as EventLoopGroup)
     }
 
     /// Initialize the connected `NIOTSConnectionChannel` with `initializer`. The most common task in initializer is to add

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -22,7 +22,7 @@ import Network
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 public final class NIOTSListenerBootstrap {
     private let group: EventLoopGroup
-    private let childGroup: NIOTSEventLoopGroup
+    private let childGroup: EventLoopGroup
     private var serverChannelInit: ((Channel) -> EventLoopFuture<Void>)?
     private var childChannelInit: ((Channel) -> EventLoopFuture<Void>)?
     private var serverChannelOptions = ChannelOptionsStorage()
@@ -36,7 +36,7 @@ public final class NIOTSListenerBootstrap {
     ///
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use for the `ServerSocketChannel`.
-    public convenience init(group: NIOTSEventLoopGroup) {
+    public convenience init(group: EventLoopGroup) {
         self.init(group: group, childGroup: group)
 
         self.serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
@@ -46,13 +46,13 @@ public final class NIOTSListenerBootstrap {
     /// Create a `NIOTSListenerBootstrap`.
     ///
     /// - parameters:
-    ///     - group: The `NIOTSEventLoopGroup` to use for the `bind` of the `NIOTSListenerChannel`
+    ///     - group: The `EventLoopGroup` to use for the `bind` of the `NIOTSListenerChannel`
     ///         and to accept new `NIOTSConnectionChannel`s with.
-    ///     - childGroup: The `NIOTSEventLoopGroup` to run the accepted `NIOTSConnectionChannel`s on.
-    public init(group: NIOTSEventLoopGroup, childGroup: NIOTSEventLoopGroup) {
+    ///     - childGroup: The `EventLoopGroup` to run the accepted `NIOTSConnectionChannel`s on.
+    public init(group: EventLoopGroup, childGroup: EventLoopGroup) {
         self.group = group
         self.childGroup = childGroup
-        
+
         self.serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
         self.childChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -34,6 +34,14 @@ public final class NIOTSListenerBootstrap {
 
     /// Create a `NIOTSListenerBootstrap` for the `EventLoopGroup` `group`.
     ///
+    /// This initializer only exists to be more in-line with the NIO core bootstraps, in that they
+    /// may be constructed with an `EventLoopGroup` and by extenstion an `EventLoop`. As such an
+    /// existing `NIOTSEventLoop` may be used to initialize this bootstrap. Where possible the
+    /// initializers accepting `NIOTSEventLoopGroup` should be used instead to avoid the wrong
+    /// type being used.
+    ///
+    /// Note that the "real" solution is described in https://github.com/apple/swift-nio/issues/674.
+    ///
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use for the `ServerSocketChannel`.
     public convenience init(group: EventLoopGroup) {
@@ -43,7 +51,23 @@ public final class NIOTSListenerBootstrap {
         self.childChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
+    /// Create a `NIOTSListenerBootstrap` for the `NIOTSEventLoopGroup` `group`.
+    ///
+    /// - parameters:
+    ///     - group: The `NIOTSEventLoopGroup` to use for the `ServerSocketChannel`.
+    public convenience init(group: NIOTSEventLoopGroup) {
+        self.init(group: group as EventLoopGroup)
+    }
+
     /// Create a `NIOTSListenerBootstrap`.
+    ///
+    /// This initializer only exists to be more in-line with the NIO core bootstraps, in that they
+    /// may be constructed with an `EventLoopGroup` and by extenstion an `EventLoop`. As such an
+    /// existing `NIOTSEventLoop` may be used to initialize this bootstrap. Where possible the
+    /// initializers accepting `NIOTSEventLoopGroup` should be used instead to avoid the wrong
+    /// type being used.
+    ///
+    /// Note that the "real" solution is described in https://github.com/apple/swift-nio/issues/674.
     ///
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use for the `bind` of the `NIOTSListenerChannel`
@@ -55,6 +79,16 @@ public final class NIOTSListenerBootstrap {
 
         self.serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
         self.childChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+    }
+
+    /// Create a `NIOTSListenerBootstrap`.
+    ///
+    /// - parameters:
+    ///     - group: The `NIOTSEventLoopGroup` to use for the `bind` of the `NIOTSListenerChannel`
+    ///         and to accept new `NIOTSConnectionChannel`s with.
+    ///     - childGroup: The `NIOTSEventLoopGroup` to run the accepted `NIOTSConnectionChannel`s on.
+    public convenience init(group: NIOTSEventLoopGroup, childGroup: NIOTSEventLoopGroup) {
+        self.init(group: group as EventLoopGroup, childGroup: childGroup as EventLoopGroup)
     }
 
     /// Initialize the `NIOTSListenerChannel` with `initializer`. The most common task in initializer is to add

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -84,7 +84,7 @@ internal final class NIOTSListenerChannel {
     private var enablePeerToPeer = false
 
     /// The event loop group to use for child channels.
-    private let childLoopGroup: NIOTSEventLoopGroup
+    private let childLoopGroup: EventLoopGroup
 
     /// The QoS to use for child channels.
     private let childChannelQoS: DispatchQoS?
@@ -103,7 +103,7 @@ internal final class NIOTSListenerChannel {
                   qos: DispatchQoS? = nil,
                   tcpOptions: NWProtocolTCP.Options,
                   tlsOptions: NWProtocolTLS.Options?,
-                  childLoopGroup: NIOTSEventLoopGroup,
+                  childLoopGroup: EventLoopGroup,
                   childChannelQoS: DispatchQoS?,
                   childTCPOptions: NWProtocolTCP.Options,
                   childTLSOptions: NWProtocolTLS.Options?) {


### PR DESCRIPTION
Motivation:

In NIO `ClientBootstrap` and `ServerBootstrap` are initialized with an
`EventLoopGroup`. Since `EventLoop` conforms to `EventLoopGroup` you can
initialize an bootstrap with an existing event loop. In NIO Transport
Services the bootstraps are initialized with a `NIOTSEventLoopGroup` and
as `NIOTSEventLoop` conforms to `EventLoop` and by extension
`EventLoopGroup` (but not `NIOTSEventLoopGroup`) it is not possible to
initialize a bootstrap with a pre-existing `NIOTSEventLoop`.

Modifications:

Change the bootstrap initializers to accept an `EventLoopGroup`.

Result:

NIO Transport Services bootstraps can be initialized with a
`NIOTSEventLoop`.