### PR TITLE
Fix availability for NWEndpoint

### DIFF
--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -301,9 +301,10 @@ extension NIOTSListenerChannel: StateManagedChannel {
             parameters.requiredLocalEndpoint = target
         case .service(_, _, _, let interface):
             parameters.requiredInterface = interface
-        case .url:
-            break
-        @unknown default:
+        default:
+            // We can't use `@unknown default` and explicitly list cases we know about since they
+            // would require availability checks within the switch statement (`.url` was added in
+            // macOS 10.15).
             ()
         }
 

--- a/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
+++ b/Sources/NIOTransportServices/SocketAddress+NWEndpoint.swift
@@ -100,9 +100,12 @@ extension SocketAddress {
             self = .init(addr, host: host.debugDescription)
         case .unix(let path):
             self = try .init(unixDomainSocketPath: path)
-        case .service, .hostPort, .url:
+        case .service, .hostPort:
             throw NIOTSErrors.UnableToResolveEndpoint()
-        @unknown default:
+        default:
+            // We can't use `@unknown default` and explicitly list cases we know about since they
+            // would require availability checks within the switch statement (`.url` was added in
+            // macOS 10.15).
             throw NIOTSErrors.UnableToResolveEndpoint()
         }
     }


### PR DESCRIPTION
Motivation:

`NWEndpoint` added a `.url` case for macOS 10.15 which commit afbbead added
support for. However, in doing so it also broke support for 10.14.

Modifications:

Handle `.url` in the `default` case and also remove `@unknown` from the
cases of the switch statements in NIOTSListenerChannel and SocketAddress
init.

Result:

Compiles on 10.14.