### PR TITLE
Correctly autoRead through the pipeline

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -625,7 +625,7 @@ extension NIOTSConnectionChannel: StateManagedChannel {
     /// A function that will trigger a socket read if necessary.
     internal func readIfNeeded0() {
         if self.options.autoRead {
-            self.read0()
+            self.pipeline.read()
         }
     }
 }

--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -22,6 +22,20 @@ import Foundation
 import Network
 
 
+func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = #file, line: UInt = #line) throws -> T {
+    do {
+        return try body()
+    } catch {
+        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: file, line: line)
+        if let defaultValue = defaultValue {
+            return defaultValue
+        } else {
+            throw error
+        }
+    }
+}
+
+
 final class EchoHandler: ChannelInboundHandler {
     typealias InboundIn = Any
     typealias OutboundOut = Any


### PR DESCRIPTION
Motivation:

When autoRead is on, the pipeline must observe the read calls in order
to be able to exert backpressure. Otherwise, autoRead is a
zero-backpressure mode, which isn't great.

Correctly call pipeline.read instead of self.read0 to avoid this.

Modifications:

- Updated NIOTSConnectionChannel to call pipeline.read().

Result:

Backpressure can be exerted.
