### PR TITLE
Add a bind timeout.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSErrors.swift
+++ b/Sources/NIOTransportServices/NIOTSErrors.swift
@@ -57,5 +57,15 @@ public enum NIOTSErrors {
     /// `UnableToResolveEndpoint` is thrown when an attempt is made to resolve a local endpoint, but
     /// insufficient information is available to create it.
     public struct UnableToResolveEndpoint: NIOTSError { }
+
+    /// `BindTimeout` is thrown when a timeout set for a `NWListenerBootstrap.bind` call has been exceeded
+    /// without successfully binding the address.
+    public struct BindTimeout: NIOTSError {
+        public var timeout: TimeAmount
+
+        public init(timeout: TimeAmount) {
+            self.timeout = timeout
+        }
+    }
 }
 #endif

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -259,5 +259,21 @@ class NIOTSListenerChannelTests: XCTestCase {
         XCTAssertEqual(promisedChannel.remoteAddress, connection.localAddress)
         XCTAssertEqual(promisedChannel.localAddress, connection.remoteAddress)
     }
+
+    func testBindTimeout() throws {
+        // Testing the bind timeout is damn fiddly, because I don't know a reliable way to force it
+        // to happen. The best approach I can think of is to set the timeout to "now".
+        // If you see this test fail, verify that it isn't a simple timing issue first.
+        let listener = NIOTSListenerBootstrap(group: self.group)
+            .bindTimeout(.nanoseconds(0))
+
+        do {
+            let channel = try listener.bind(host: "localhost", port: 0).wait()
+            XCTAssertNoThrow(try channel.close().wait())
+            XCTFail("Did not throw")
+        } catch {
+            XCTAssertEqual(error as? NIOTSErrors.BindTimeout, NIOTSErrors.BindTimeout(timeout: .nanoseconds(0)), "unexpected error: \(error)")
+        }
+    }
 }
 #endif


### PR DESCRIPTION
Motivation:

In Network.framework it is possible for a bind operation to take a while
to complete if it ends up waiting for appropriate network conditions. As
a result, unlike in the POSIX case, we need to give users the ability
to configure the maximum amount of time they'd be willing to wait for a
bind call to succeed.

Modifications:

- Add a bind timeout.

Result:

Users won't have to wait forever.
