### PR TITLE
Update Readme to recommend using Xcode package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and then adding the NIOTransportServices module to your target dependencies.
 
 If your project is set up as an Xcode project and you're using Xcode 11+, you can add NIO Transport Services as a dependency to your Xcode project by clicking File -> Swift Packages -> Add Package Dependency. In the upcoming dialog, please enter `https://github.com/apple/swift-nio-transport-services.git` and click Next twice. Finally, make sure `NIOTransportServices` is selected and click finish. Now will be able to `import NIOTransportServices` in your project.
 
-You can also use SwiftNIO Transport Services in an iOS project is through CocoaPods:
+You can also use SwiftNIO Transport Services in an iOS project through CocoaPods:
 
     pod 'SwiftNIO', '~> 2.0.0'
     pod 'SwiftNIOTransportServices', '~> 1.0.0'

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Network.framework is Apple's reference implementation of the [proposed post-sock
 
 NIO Transport Services primarily uses SwiftPM as its build tool, so we recommend using that as well. If you want to depend on NIO Transport Services in your own project, it's as simple as adding a dependencies clause to your Package.swift:
 
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.1.1")
-    ]
+```
+dependencies: [
+    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.1.1")
+]
+```
 
 and then adding the NIOTransportServices module to your target dependencies.
 
@@ -31,8 +33,15 @@ You can also use SwiftNIO Transport Services in an iOS project is through CocoaP
     pod 'SwiftNIO', '~> 2.0.0'
     pod 'SwiftNIOTransportServices', '~> 1.0.0'
 
-Do note however that Network.framework requires macOS 10.14+, iOS 12+, or tvOS 12+.
+If you want to develop SwiftNIO with Xcode 10, you have to generate an Xcode project:
 
+```
+swift package generate-xcodeproj
+```
+
+and add the project as a sub-project by dragging it into your iOS project and adding the framework (`NIOTransportServices.framework`) in 'Build Phases' -> 'Link Binary Libraries'.
+
+Do note however that Network.framework requires macOS 10.14+, iOS 12+, or tvOS 12+.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ Network.framework is Apple's reference implementation of the [proposed post-sock
 
 ## How to Use?
 
-Today, the easiest way to use SwiftNIO Transport Services in an iOS project is through CocoaPods:
+NIO Transport Services primarily uses SwiftPM as its build tool, so we recommend using that as well. If you want to depend on NIO Transport Services in your own project, it's as simple as adding a dependencies clause to your Package.swift:
+
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.1.1")
+    ]
+
+and then adding the NIOTransportServices module to your target dependencies.
+
+If your project is set up as an Xcode project and you're using Xcode 11+, you can add NIO Transport Services as a dependency to your Xcode project by clicking File -> Swift Packages -> Add Package Dependency. In the upcoming dialog, please enter `https://github.com/apple/swift-nio-transport-services.git` and click Next twice. Finally, make sure `NIOTransportServices` is selected and click finish. Now will be able to `import NIOTransportServices` in your project.
+
+You can also use SwiftNIO Transport Services in an iOS project is through CocoaPods:
 
     pod 'SwiftNIO', '~> 2.0.0'
     pod 'SwiftNIOTransportServices', '~> 1.0.0'
-
-You can also use the Swift Package Manager:
-
-```
-swift build
-```
-
-and add the project as a sub-project by dragging it into your iOS project and adding the frameworks (such as `NIO.framework`) in 'Build Phases' -> 'Link Binary Libraries'.
 
 Do note however that Network.framework requires macOS 10.14+, iOS 12+, or tvOS 12+.
 


### PR DESCRIPTION
Add instructions on how to include NIO Transport Services using SPM

### Motivation:

The best method now that Xcode has SPM support is to use the package, and not Cocoapods anymore

### Modifications:

Update the readme

### Result:

Everyone uses SPM now…
