### PR TITLE
Namespace ChannelOptions.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.9.0"),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -16,42 +16,59 @@
 #if canImport(Network)
 import NIO
 
-
-/// `NIOTSWaitForActivityOption` controls whether the `Channel` should wait for connection changes
-/// during the connection process if the connection attempt fails. If Network.framework believes that
-/// a connection may succeed in future, it may transition into the `.waiting` state. By default, this option
-/// is set to `true` and NIO allows this state transition, though it does count time in that state against
-/// the timeout. If this option is set to `false`, transitioning into this state will be treated the same as
-/// transitioning into the `failed` state, causing immediate connection failure.
-///
-/// This option is only valid with `NIOTSConnectionBootstrap`.
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-public struct NIOTSWaitForActivityOption: ChannelOption, Equatable {
-    public typealias Value = Bool
-
-    public init() {}
-}
-
-
-/// `NIOTSEnablePeerToPeerOption` controls whether the `Channel` will advertise services using peer-to-peer
-/// connectivity. Setting this to true is the equivalent of setting `NWParameters.enablePeerToPeer` to
-/// `true`. By default this option is set to `false`.
-///
-/// This option must be set on the bootstrap: setting it after the channel is initialized will have no effect.
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-public struct NIOTSEnablePeerToPeerOption: ChannelOption, Equatable {
-    public typealias Value = Bool
-
-    public init() {}
-}
-
-
 /// Options that can be set explicitly and only on bootstraps provided by `NIOTransportServices`.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 public struct NIOTSChannelOptions {
     /// - seealso: `NIOTSWaitForActivityOption`.
-    public static let waitForActivity = NIOTSWaitForActivityOption()
+    public static let waitForActivity = NIOTSChannelOptions.Types.NIOTSWaitForActivityOption()
 
-    public static let enablePeerToPeer = NIOTSEnablePeerToPeerOption()
+    public static let enablePeerToPeer = NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption()
 }
+
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSChannelOptions {
+    public enum Types {
+        /// `NIOTSWaitForActivityOption` controls whether the `Channel` should wait for connection changes
+        /// during the connection process if the connection attempt fails. If Network.framework believes that
+        /// a connection may succeed in future, it may transition into the `.waiting` state. By default, this option
+        /// is set to `true` and NIO allows this state transition, though it does count time in that state against
+        /// the timeout. If this option is set to `false`, transitioning into this state will be treated the same as
+        /// transitioning into the `failed` state, causing immediate connection failure.
+        ///
+        /// This option is only valid with `NIOTSConnectionBootstrap`.
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSWaitForActivityOption: ChannelOption, Equatable {
+            public typealias Value = Bool
+
+            public init() {}
+        }
+
+
+        /// `NIOTSEnablePeerToPeerOption` controls whether the `Channel` will advertise services using peer-to-peer
+        /// connectivity. Setting this to true is the equivalent of setting `NWParameters.enablePeerToPeer` to
+        /// `true`. By default this option is set to `false`.
+        ///
+        /// This option must be set on the bootstrap: setting it after the channel is initialized will have no effect.
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSEnablePeerToPeerOption: ChannelOption, Equatable {
+            public typealias Value = Bool
+
+            public init() {}
+        }
+    }
+}
+
+/// See: `NIOTSChannelOptions.Types.NIOTSWaitForActivityOption`.
+@available(*, deprecated, renamed: "NIOTSChannelOptions.Types.NIOTSWaitForActivityOption")
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+public typealias NIOTSWaitForActivityOption = NIOTSChannelOptions.Types.NIOTSWaitForActivityOption
+
+
+/// See: `NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption`
+@available(*, deprecated, renamed: "NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption")
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+public typealias NIOTSEnablePeerToPeerOption = NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption
+
+
 #endif

--- a/Sources/NIOTransportServices/NIOTSErrors.swift
+++ b/Sources/NIOTransportServices/NIOTSErrors.swift
@@ -36,7 +36,7 @@ public enum NIOTSErrors {
     /// `UnsupportedSocketOption` is thrown when an attempt is made to configure a socket option that
     /// is not supported by Network.framework.
     public struct UnsupportedSocketOption: NIOTSError {
-        public let optionValue: SocketOption
+        public let optionValue: ChannelOptions.Types.SocketOption
 
         public static func ==(lhs: UnsupportedSocketOption, rhs: UnsupportedSocketOption) -> Bool {
             return lhs.optionValue == rhs.optionValue

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -178,12 +178,12 @@ extension NIOTSListenerChannel: Channel {
 
         // TODO: Many more channel options, both from NIO and Network.framework.
         switch option {
-        case is AutoReadOption:
+        case is ChannelOptions.Types.AutoReadOption:
             // AutoRead is currently mandatory for TS listeners.
-            if value as! AutoReadOption.Value == false {
+            if value as! ChannelOptions.Types.AutoReadOption.Value == false {
                 throw ChannelError.operationUnsupported
             }
-        case let optionValue as SocketOption:
+        case let optionValue as ChannelOptions.Types.SocketOption:
             // SO_REUSEADDR and SO_REUSEPORT are handled here.
             switch (optionValue.level, optionValue.name) {
             case (SOL_SOCKET, SO_REUSEADDR):
@@ -193,8 +193,8 @@ extension NIOTSListenerChannel: Channel {
             default:
                 try self.tcpOptions.applyChannelOption(option: optionValue, value: value as! SocketOptionValue)
             }
-        case is NIOTSEnablePeerToPeerOption:
-            self.enablePeerToPeer = value as! NIOTSEnablePeerToPeerOption.Value
+        case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
+            self.enablePeerToPeer = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
         default:
             fatalError("option \(option) not supported")
         }
@@ -218,9 +218,9 @@ extension NIOTSListenerChannel: Channel {
         }
 
         switch option {
-        case is AutoReadOption:
+        case is ChannelOptions.Types.AutoReadOption:
             return autoRead as! Option.Value
-        case let optionValue as SocketOption:
+        case let optionValue as ChannelOptions.Types.SocketOption:
             // SO_REUSEADDR and SO_REUSEPORT are handled here.
             switch (optionValue.level, optionValue.name) {
             case (SOL_SOCKET, SO_REUSEADDR):
@@ -230,7 +230,7 @@ extension NIOTSListenerChannel: Channel {
             default:
                 return try self.tcpOptions.valueFor(socketOption: optionValue) as! Option.Value
             }
-        case is NIOTSEnablePeerToPeerOption:
+        case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
             return self.enablePeerToPeer as! Option.Value
         default:
             fatalError("option \(option) not supported")

--- a/Sources/NIOTransportServices/TCPOptions+SocketChannelOption.swift
+++ b/Sources/NIOTransportServices/TCPOptions+SocketChannelOption.swift
@@ -22,7 +22,7 @@ import Network
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 internal extension NWProtocolTCP.Options {
     /// Apply a given channel `SocketOption` to this protocol options state.
-    func applyChannelOption(option: SocketOption, value: SocketOptionValue) throws {
+    func applyChannelOption(option: ChannelOptions.Types.SocketOption, value: SocketOptionValue) throws {
         switch (option.level, option.name) {
         case (IPPROTO_TCP, TCP_NODELAY):
             self.noDelay = value != 0
@@ -54,7 +54,7 @@ internal extension NWProtocolTCP.Options {
     }
 
     /// Obtain the given `SocketOption` value for this protocol options state.
-    func valueFor(socketOption option: SocketOption) throws -> SocketOptionValue {
+    func valueFor(socketOption option: ChannelOptions.Types.SocketOption) throws -> SocketOptionValue {
         switch (option.level, option.name) {
         case (IPPROTO_TCP, TCP_NODELAY):
             return self.noDelay ? 1 : 0


### PR DESCRIPTION
Motivation:

In NIO 2.9.0 we moved all first-party `ChannelOption` types into their
own namespace. That was a good idea, but NIOTS uses them too and so it
now encounters build warnings. Additionally, NIOTS defines its own
`ChannelOption`s, and so should namespace those as well.

Modifications:

- Updated the code to use the namespaced `ChannelOption` types.
- Namespaced our own.

Result:

More namespacing.
