### PR TITLE
Take advantage of flatSubmit.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -169,7 +169,7 @@ public final class NIOTSConnectionBootstrap {
         let initializer = self.channelInitializer ?? { _ in conn.eventLoop.makeSucceededFuture(()) }
         let channelOptions = self.channelOptions
 
-        return conn.eventLoop.submit {
+        return conn.eventLoop.flatSubmit {
             return channelOptions.applyAllChannelOptions(to: conn).flatMap {
                 initializer(conn)
             }.flatMap {
@@ -191,7 +191,7 @@ public final class NIOTSConnectionBootstrap {
                 conn.close(promise: nil)
                 throw $0
             }
-        }.flatMap { $0 }
+        }
     }
 }
 

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -347,9 +347,9 @@ private class AcceptHandler: ChannelInboundHandler {
         if childLoop === ctxEventLoop {
             fireThroughPipeline(setupChildChannel())
         } else {
-            fireThroughPipeline(childLoop.submit {
+            fireThroughPipeline(childLoop.flatSubmit {
                 return setupChildChannel()
-            }.flatMap { $0 }.hop(to: ctxEventLoop))
+            }.hop(to: ctxEventLoop))
         }
     }
 }


### PR DESCRIPTION
Motivation:

We can remove a couple of unnecessary flatMap { $0 } operations by way
of using flatSubmit, added in NIO 2.9.0.

Modifications:

- Replace flatMap { $0 } with flatSubmit().

Result:

Remove some code noise.
