### PR TITLE
Fixup some warnings in the tests.

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -264,7 +264,7 @@ class NIOTSConnectionChannelTests: XCTestCase {
             XCTAssertEqual(option.high, 64 * 1024)
             XCTAssertEqual(option.low, 32 * 1024)
 
-            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 1, high: 101))
+            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 1, high: 101))
         }.flatMap {
             connection.getOption(ChannelOptions.writeBufferWaterMark)
         }.map {
@@ -291,7 +291,7 @@ class NIOTSConnectionChannelTests: XCTestCase {
             .wait()
 
         // We're going to set some helpful watermarks, and allocate a big buffer.
-        XCTAssertNoThrow(try connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 2, high: 2048)).wait())
+        XCTAssertNoThrow(try connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 2, high: 2048)).wait())
         var buffer = connection.allocator.buffer(capacity: 2048)
         buffer.writeBytes(repeatElement(UInt8(4), count: 2048))
 
@@ -427,36 +427,36 @@ class NIOTSConnectionChannelTests: XCTestCase {
             XCTAssertTrue(connection.isWritable)
         }.wait()
 
-        try connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 128, high: 256)).flatMap {
+        try connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 128, high: 256)).flatMap {
             // High to 256, low to 128. No writability change.
             XCTAssertEqual(writabilities, [])
             XCTAssertTrue(connection.isWritable)
 
-            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 128, high: 255))
+            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 128, high: 255))
         }.flatMap {
             // High to 255, low to 127. Channel becomes not writable.
             XCTAssertEqual(writabilities, [false])
             XCTAssertFalse(connection.isWritable)
 
-            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 128, high: 256))
+            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 128, high: 256))
         }.flatMap {
             // High back to 256, low to 128. No writability change.
             XCTAssertEqual(writabilities, [false])
             XCTAssertFalse(connection.isWritable)
 
-            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 256, high: 1024))
+            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 256, high: 1024))
         }.flatMap {
             // High to 1024, low to 128. No writability change.
             XCTAssertEqual(writabilities, [false])
             XCTAssertFalse(connection.isWritable)
 
-            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 257, high: 1024))
+            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 257, high: 1024))
         }.flatMap {
             // Low to 257, channel becomes writable again.
             XCTAssertEqual(writabilities, [false, true])
             XCTAssertTrue(connection.isWritable)
 
-            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 256, high: 1024))
+            return connection.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 256, high: 1024))
         }.map {
             // Low back to 256, no writability change.
             XCTAssertEqual(writabilities, [false, true])

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
@@ -34,7 +34,7 @@ class NIOTSSocketOptionTests: XCTestCase {
     }
 
     private func assertProperty<T: Equatable>(called path: KeyPath<NWProtocolTCP.Options, T>,
-                                              correspondsTo socketOption: SocketOption,
+                                              correspondsTo socketOption: ChannelOptions.Types.SocketOption,
                                               defaultsTo defaultValue: T,
                                               and defaultSocketOptionValue: SocketOptionValue,
                                               canBeSetTo unusualValue: SocketOptionValue,
@@ -57,90 +57,90 @@ class NIOTSSocketOptionTests: XCTestCase {
 
     func testReadingAndSettingNoDelay() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.noDelay,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_NODELAY),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_NODELAY),
                                 defaultsTo: false, and: 0,
                                 canBeSetTo: 1, whichLeadsTo: true)
     }
 
     func testReadingAndSettingNoPush() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.noPush,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_NOPUSH),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_NOPUSH),
                                 defaultsTo: false, and: 0,
                                 canBeSetTo: 1, whichLeadsTo: true)
     }
 
     func testReadingAndSettingNoOpt() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.noOptions,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_NOOPT),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_NOOPT),
                                 defaultsTo: false, and: 0,
                                 canBeSetTo: 1, whichLeadsTo: true)
     }
 
     func testReadingAndSettingKeepaliveCount() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.keepaliveCount,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_KEEPCNT),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPCNT),
                                 defaultsTo: 0, and: 0,
                                 canBeSetTo: 5, whichLeadsTo: 5)
     }
 
     func testReadingAndSettingKeepaliveIdle() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.keepaliveIdle,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_KEEPALIVE),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPALIVE),
                                 defaultsTo: 0, and: 0,
                                 canBeSetTo: 5, whichLeadsTo: 5)
     }
 
     func testReadingAndSettingKeepaliveInterval() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.keepaliveInterval,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_KEEPINTVL),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPINTVL),
                                 defaultsTo: 0, and: 0,
                                 canBeSetTo: 5, whichLeadsTo: 5)
     }
 
     func testReadingAndSettingMaxSeg() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.maximumSegmentSize,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_MAXSEG),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_MAXSEG),
                                 defaultsTo: 0, and: 0,
                                 canBeSetTo: 5, whichLeadsTo: 5)
     }
 
     func testReadingAndSettingConnectTimeout() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.connectionTimeout,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_CONNECTIONTIMEOUT),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_CONNECTIONTIMEOUT),
                                 defaultsTo: 0, and: 0,
                                 canBeSetTo: 5, whichLeadsTo: 5)
     }
 
     func testReadingAndSettingConnectDropTime() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.connectionDropTime,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_RXT_CONNDROPTIME),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_RXT_CONNDROPTIME),
                                 defaultsTo: 0, and: 0,
                                 canBeSetTo: 5, whichLeadsTo: 5)
     }
 
     func testReadingAndSettingFinDrop() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.retransmitFinDrop,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_RXT_FINDROP),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_RXT_FINDROP),
                                 defaultsTo: false, and: 0,
                                 canBeSetTo: 1, whichLeadsTo: true)
     }
 
     func testReadingAndSettingAckStretching() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.disableAckStretching,
-                                correspondsTo: SocketOption(level: IPPROTO_TCP, name: TCP_SENDMOREACKS),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_SENDMOREACKS),
                                 defaultsTo: false, and: 0,
                                 canBeSetTo: 1, whichLeadsTo: true)
     }
 
     func testReadingAndSettingKeepalive() throws {
         try self.assertProperty(called: \NWProtocolTCP.Options.enableKeepalive,
-                                correspondsTo: SocketOption(level: SOL_SOCKET, name: SO_KEEPALIVE),
+                                correspondsTo: ChannelOptions.Types.SocketOption(level: SOL_SOCKET, name: SO_KEEPALIVE),
                                 defaultsTo: false, and: 0,
                                 canBeSetTo: 1, whichLeadsTo: true)
     }
 
     func testWritingNonexistentSocketOption() {
-        let option = SocketOption(level: Int32.max, name: Int32.max)
+        let option = ChannelOptions.Types.SocketOption(level: Int32.max, name: Int32.max)
 
         do {
             try self.options.applyChannelOption(option: option, value: 0)
@@ -153,7 +153,7 @@ class NIOTSSocketOptionTests: XCTestCase {
     }
 
     func testReadingNonexistentSocketOption() {
-        let option = SocketOption(level: Int32.max, name: Int32.max)
+        let option = ChannelOptions.Types.SocketOption(level: Int32.max, name: Int32.max)
 
         do {
             _ = try self.options.valueFor(socketOption: option)

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -22,17 +22,17 @@ import Network
 
 
 private extension Channel {
-    private func getSocketOption(_ option: SocketOption) -> EventLoopFuture<SocketOptionValue> {
+    private func getSocketOption(_ option: ChannelOptions.Types.SocketOption) -> EventLoopFuture<SocketOptionValue> {
         return self.getOption(option)
     }
 
-    private func setSocketOption(_ option: SocketOption, to value: SocketOptionValue) -> EventLoopFuture<Void> {
+    private func setSocketOption(_ option: ChannelOptions.Types.SocketOption, to value: SocketOptionValue) -> EventLoopFuture<Void> {
         return self.setOption(option, value: value)
     }
 
     /// Asserts that a given socket option has a default value, that its value can be changed to a new value, and that it can then be
     /// switched back.
-    func assertOptionRoundTrips(option: SocketOption, initialValue: SocketOptionValue, testAlternativeValue: SocketOptionValue) -> EventLoopFuture<Void> {
+    func assertOptionRoundTrips(option: ChannelOptions.Types.SocketOption, initialValue: SocketOptionValue, testAlternativeValue: SocketOptionValue) -> EventLoopFuture<Void> {
         return self.getSocketOption(option).flatMap { actualInitialValue in
             XCTAssertEqual(actualInitialValue, initialValue)
             return self.setSocketOption(option, to: testAlternativeValue)
@@ -61,7 +61,7 @@ class NIOTSSocketOptionsOnChannelTests: XCTestCase {
         XCTAssertNoThrow(try self.group.syncShutdownGracefully())
     }
 
-    func assertChannelOptionAfterCreation(option: SocketOption, initialValue: SocketOptionValue, testAlternativeValue: SocketOptionValue) throws {
+    func assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption, initialValue: SocketOptionValue, testAlternativeValue: SocketOptionValue) throws {
         let listener = try NIOTSListenerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
         defer {
             XCTAssertNoThrow(try listener.close().wait())
@@ -76,51 +76,51 @@ class NIOTSSocketOptionsOnChannelTests: XCTestCase {
     }
 
     func testNODELAY() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_NODELAY), initialValue: 1, testAlternativeValue: 0)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_NODELAY), initialValue: 1, testAlternativeValue: 0)
     }
 
     func testNOPUSH() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_NOPUSH), initialValue: 0, testAlternativeValue: 1)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_NOPUSH), initialValue: 0, testAlternativeValue: 1)
     }
 
     func testNOOPT() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_NOOPT), initialValue: 0, testAlternativeValue: 1)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_NOOPT), initialValue: 0, testAlternativeValue: 1)
     }
 
     func testKEEPCNT() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_KEEPCNT), initialValue: 0, testAlternativeValue: 5)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPCNT), initialValue: 0, testAlternativeValue: 5)
     }
 
     func testKEEPALIVE() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_KEEPALIVE), initialValue: 0, testAlternativeValue: 5)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPALIVE), initialValue: 0, testAlternativeValue: 5)
     }
 
     func testKEEPINTVL() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_KEEPINTVL), initialValue: 0, testAlternativeValue: 5)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPINTVL), initialValue: 0, testAlternativeValue: 5)
     }
 
     func testMAXSEG() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_MAXSEG), initialValue: 0, testAlternativeValue: 5)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_MAXSEG), initialValue: 0, testAlternativeValue: 5)
     }
 
     func testCONNECTIONTIMEOUT() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_CONNECTIONTIMEOUT), initialValue: 0, testAlternativeValue: 5)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_CONNECTIONTIMEOUT), initialValue: 0, testAlternativeValue: 5)
     }
 
     func testRXT_CONNDROPTIME() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_RXT_CONNDROPTIME), initialValue: 0, testAlternativeValue: 5)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_RXT_CONNDROPTIME), initialValue: 0, testAlternativeValue: 5)
     }
 
     func testRXT_FINDROP() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_RXT_FINDROP), initialValue: 0, testAlternativeValue: 1)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_RXT_FINDROP), initialValue: 0, testAlternativeValue: 1)
     }
 
     func testSENDMOREACKS() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: IPPROTO_TCP, name: TCP_SENDMOREACKS), initialValue: 0, testAlternativeValue: 1)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_SENDMOREACKS), initialValue: 0, testAlternativeValue: 1)
     }
 
     func testSO_KEEPALIVE() throws {
-        try self.assertChannelOptionAfterCreation(option: SocketOption(level: SOL_SOCKET, name: SO_KEEPALIVE), initialValue: 0, testAlternativeValue: 1)
+        try self.assertChannelOptionAfterCreation(option: ChannelOptions.Types.SocketOption(level: SOL_SOCKET, name: SO_KEEPALIVE), initialValue: 0, testAlternativeValue: 1)
     }
 
     func testMultipleSocketOptions() throws {


### PR DESCRIPTION
Motivation:

Sadly the previous NIO warnings patch failed to notice that the tests
had a bunch of errors, despite the fact that those tests were
(repeatedly) run.

Modifications:

Directly apply the fixits.

Result:

Fewer warnings
