### PR TITLE
Conform to ClientTransportBootstrap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.9.0"),
+        .package(url: "https://github.com/Yasumoto/swift-nio.git", .branch("yasumoto-client-bootstrap-protocol")),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Yasumoto/swift-nio.git", .branch("yasumoto-client-bootstrap-protocol")),
+        .package(url: "https://github.com/Yasumoto/swift-nio.git", .revision("0d856abd8911c540e889f98475583a9db5d1e5c8")),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Yasumoto/swift-nio.git", .revision("0d856abd8911c540e889f98475583a9db5d1e5c8")),
+        .package(url: "https://github.com/Yasumoto/swift-nio.git", .branch("yasumoto-client-bootstrap-protocol")),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -20,7 +20,7 @@ import Dispatch
 import Network
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-public final class NIOTSConnectionBootstrap {
+public final class NIOTSConnectionBootstrap: ClientTransportBootstrap {
     private let group: EventLoopGroup
     private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     private var connectTimeout: TimeAmount = TimeAmount.seconds(10)


### PR DESCRIPTION
_[One line description of your change]_

### Motivation:

This builds on https://github.com/apple/swift-nio/pull/1253 and allows users to more easily swap between `ClientBootstrap` and `NIOTSConnectionBootstrap`.

### Modifications:

Conformed `NIOTSConnectionBootstrap` to `ClientTransportBootstrap`.

I've also temporarily modified `Package.swift` to allow folks to try this out on `AsyncHTTPClient` if they'd like.

### Result:

Additional protocol conformance.
