### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Code of Conduct
+To be a truly great community, SwiftNIO needs to welcome developers from all walks of life,
+with different backgrounds, and with a wide range of experience. A diverse and friendly
+community will have more great ideas, more unique perspectives, and produce more great
+code. We will work diligently to make the SwiftNIO community welcoming to everyone.
+
+To give clarity of what is expected of our members, SwiftNIO has adopted the code of conduct
+defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source
+communities, and we think it articulates our values well. The full text is copied below:
+
+### Contributor Code of Conduct v1.3
+As contributors and maintainers of this project, and in the interest of fostering an open and
+welcoming community, we pledge to respect all people who contribute through reporting
+issues, posting feature requests, updating documentation, submitting pull requests or patches,
+and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression, sexual
+orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or
+nationality.
+
+Examples of unacceptable behavior by participants include:
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other’s private information, such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of
+Conduct, or to ban temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and
+consistently applying these principles to every aspect of managing this project. Project
+maintainers who do not follow or enforce the Code of Conduct may be permanently removed
+from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an
+individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+contacting a project maintainer at [swift-server-conduct@group.apple.com](mailto:swift-server-conduct@group.apple.com). All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and appropriate to the
+circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
+of an incident.
+
+*This policy is adapted from the Contributor Code of Conduct [version 1.3.0](https://contributor-covenant.org/version/1/3/0/).*
+
+### Reporting
+A working group of community members is committed to promptly addressing any [reported issues](mailto:swift-server-conduct@group.apple.com).
+Working group members are volunteers appointed by the project lead, with a
+preference for individuals with varied backgrounds and perspectives. Membership is expected
+to change regularly, and may grow or shrink.


### PR DESCRIPTION
Motivation:

The code of conduct document is missing.

Modifications:

Add CODE_OF_CONDUCT.md from apple/swift-nio

Result:

We have a code of conduct