### PR TITLE
Adopt NIOAtomic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.9.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.0"),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -81,7 +81,7 @@ private struct BackpressureManager {
     /// because in most cases these loads/stores will be free, as the user will never actually check the
     /// channel writability from another thread, meaning this cache line is uncontended. CAS is never free:
     /// it always has some substantial runtime cost over loads/stores.
-    let writable = Atomic<Bool>(value: true)
+    let writable = NIOAtomic<Bool>.makeAtomic(value: true)
 
     /// The number of bytes outstanding on the network.
     private var outstandingBytes: Int = 0
@@ -184,7 +184,7 @@ internal final class NIOTSConnectionChannel {
     internal var state: ChannelState<ActiveSubstate> = .idle
 
     /// The active state, used for safely reporting the channel state across threads.
-    internal var isActive0: Atomic<Bool> = Atomic(value: false)
+    internal var isActive0: NIOAtomic<Bool> = .makeAtomic(value: false)
 
     /// The kinds of channel activation this channel supports
     internal let supportedActivationType: ActivationType = .connect

--- a/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
@@ -49,7 +49,7 @@ import Network
 /// preferred networking backend.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 public final class NIOTSEventLoopGroup: EventLoopGroup {
-    private let index = Atomic<Int>(value: 0)
+    private let index = NIOAtomic<Int>.makeAtomic(value: 0)
     private let eventLoops: [NIOTSEventLoop]
 
     public init(loopCount: Int = 1, defaultQoS: DispatchQoS = .default) {

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -65,7 +65,7 @@ internal final class NIOTSListenerChannel {
     internal let supportedActivationType: ActivationType = .bind
 
     /// The active state, used for safely reporting the channel state across threads.
-    internal var isActive0: Atomic<Bool> = Atomic(value: false)
+    internal var isActive0: NIOAtomic<Bool> = .makeAtomic(value: false)
 
     /// Whether a call to NWListener.receive has been made, but the completion
     /// handler has not yet been invoked.

--- a/Sources/NIOTransportServices/StateManagedChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedChannel.swift
@@ -104,7 +104,7 @@ internal protocol StateManagedChannel: Channel, ChannelCore {
 
     var state: ChannelState<ActiveSubstate> { get set }
 
-    var isActive0: Atomic<Bool> { get set }
+    var isActive0: NIOAtomic<Bool> { get set }
 
     var tsEventLoop: NIOTSEventLoop { get }
 

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -103,7 +103,7 @@ class NIOTSEventLoopTest: XCTestCase {
             weakELG = group
             weakEL = group.next()
 
-            let counter = Atomic<Int>(value: 0)
+            let counter = NIOAtomic<Int>.makeAtomic(value: 0)
             let acceptedChan = group.next().makePromise(of: Channel.self)
             let server = try NIOTSListenerBootstrap(group: group)
                 .childChannelInitializer { channel in


### PR DESCRIPTION
Motivation:

We deprecated Atomic because we made a new, better one. We should use
it.

Modifications:

Replaced all use of Atomic with NIOAtomic.

Result:

Better performance, fewer compiler warnings.
