### PR TITLE
Made NIOTSEventLoop public

### DIFF
--- a/Sources/NIOTransportServices/NIOTSEventLoop.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoop.swift
@@ -52,7 +52,7 @@ fileprivate enum LifecycleState {
 
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-internal class NIOTSEventLoop: QoSEventLoop {
+public class NIOTSEventLoop: QoSEventLoop {
     private let loop: DispatchQueue
     private let taskQueue: DispatchQueue
     private let inQueueKey: DispatchSpecificKey<UUID>
@@ -149,7 +149,7 @@ internal class NIOTSEventLoop: QoSEventLoop {
         }
     }
 
-    func preconditionInEventLoop(file: StaticString, line: UInt) {
+    public func preconditionInEventLoop(file: StaticString, line: UInt) {
         dispatchPrecondition(condition: .onQueue(self.loop))
     }
 }


### PR DESCRIPTION
_[One line description of your change]_

I have made NIOTSEventLoop public so I can recognise one and create the correct NIOClientTCPBootstrap for it. 

This is required for the PR https://github.com/swift-server/async-http-client/pull/184 which adds support for NIO Transport Services to AsyncHTTPClient. The changes mean I can create the correct NIOClientTCPBootstrap for the eventLoop supplied

### Modifications:

Replaced `internal` for `public` in front of `NIOTSEventLoop`

