### PR TITLE
Add canImport(Network) to NIOTSBootstraps.swift

### DIFF
--- a/Sources/NIOTransportServices/NIOTSBootstraps.swift
+++ b/Sources/NIOTransportServices/NIOTSBootstraps.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Network)
 import NIO
 
 /// Shared functionality across NIOTS bootstraps.
@@ -21,3 +22,5 @@ internal enum NIOTSBootstraps {
         return group is NIOTSEventLoop || group is NIOTSEventLoopGroup
     }
 }
+
+#endif


### PR DESCRIPTION
Add canImport(Network) to NIOTSBootstraps.swift

### Motivation:

Still needs to compile in Linux