### PR TITLE
add missing canImport(Network) to tests

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOFilterEmptyWritesHandlerTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOFilterEmptyWritesHandlerTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Network)
 import XCTest
 import NIO
 import NIOTransportServices
@@ -260,3 +261,4 @@ class NIOFilterEmptyWritesHandlerTests: XCTestCase {
         thenEmptyWritePromise = nil
     }
 }
+#endif


### PR DESCRIPTION
The tests should also compile (and do nothing) on Linux.