### PR TITLE
Directly support the allowLocalEndpointReuse channel option

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .executable(name: "NIOTSHTTPServer", targets: ["NIOTSHTTPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.15.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.19.0"),
     ],
     targets: [
         .target(name: "NIOTransportServices",

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -54,6 +54,18 @@ extension NIOTSChannelOptions {
 
             public init() {}
         }
+        
+        /// `NIOTSAllowLocalEndpointReuse` controls whether the `Channel` can reuse a TCP address recently used.
+        ///  Setting this to true is the equivalent of setting at least one of REUSEADDR and REUSEPORT to
+        /// `true`. By default this option is set to `false`.
+        ///
+        /// This option must be set on the bootstrap: setting it after the channel is initialized will have no effect.
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSAllowLocalEndpointReuse: ChannelOption, Equatable {
+            public typealias Value = Bool
+
+            public init() {}
+        }
     }
 }
 

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -58,7 +58,6 @@ extension NIOTSChannelOptions {
             public init() {}
         }
 
-
         /// `NIOTSEnablePeerToPeerOption` controls whether the `Channel` will advertise services using peer-to-peer
         /// connectivity. Setting this to true is the equivalent of setting `NWParameters.enablePeerToPeer` to
         /// `true`. By default this option is set to `false`.
@@ -79,6 +78,9 @@ extension NIOTSChannelOptions {
         @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
         public struct NIOTSAllowLocalEndpointReuse: ChannelOption, Equatable {
             public typealias Value = Bool
+            
+            public init() {}
+        }
 
         /// `NIOTSCurrentPathOption` accesses the `NWConnection.currentPath` of the underlying connection.
         ///

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -21,6 +21,9 @@ public struct NIOTSChannelOptions {
     public static let waitForActivity = NIOTSChannelOptions.Types.NIOTSWaitForActivityOption()
 
     public static let enablePeerToPeer = NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption()
+    
+    /// - See: NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse
+    public static let allowLocalEndpointReuse = NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse()
 }
 
 

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -250,7 +250,7 @@ extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
     public func applyChannelOption(_ option: NIOTCPShorthandOption) -> Self? {
         // Currently the only thing we have special action for is allowImmediateEndpointAddressReuse
         // deal with that and let the default behaviour take care of everything else.
-        if option == NIOTCPShorthandOption.allowImmediateEndpointAddressReuse {
+        if option == NIOTCPShorthandOption.allowImmediateLocalEndpointAddressReuse {
             return channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)
         }
         return .none
@@ -276,7 +276,7 @@ extension NIOTSConnectionBootstrap {
     @usableFromInline
     func channelOption(_ option: NIOTCPShorthandOption) -> NIOTSConnectionBootstrap {
         let applier = NIOTSConnectionBootstrap_Applier(contained: self)
-        return option.applyOptionDefaultMapping(with: applier).contained
+        return option.applyOptionDefaultMapping(applier).contained
     }
     
     fileprivate struct NIOTSConnectionBootstrap_Applier : NIOChannelOptionAppliable {

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -247,7 +247,7 @@ extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
     /// - parameters:
     ///     - options:  The options to try applying - the options applied should be consumed from here.
     /// - returns: The updated bootstrap with and options applied.
-    public func applyOptions(_ options: inout NIOTCPShorthandOptions) -> Self {
+    public func _applyOptions(_ options: inout NIOTCPShorthandOptions) -> Self {
         var toReturn = self
         if options.consumeAllowImmediateLocalEndpointAddressReuse().isSet {
             toReturn = channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -110,6 +110,26 @@ public final class NIOTSConnectionBootstrap {
         channelOptions.append(key: option, value: value)
         return self
     }
+    
+    /// Specifies some `ChannelOption`s to be applied to the `NIOTSConnectionChannel`.
+    /// - See: channelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The updated client bootstrap (`self` being mutated)
+    @inlinable
+    public func channelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
+        var toReturn = self
+        for option in options {
+            // Check for mapping specific to us.
+            toReturn = applyChannelOption(option) ?? option.applyOption(with: toReturn)
+            /* if let updatedValue = applyChannelOption(option) {
+                toReturn = NIOClientTCPBootstrap(updatedUnderlying,
+                                                 tlsEnabler: self.tlsEnablerTypeErased)
+            } else {
+                toReturn = option.applyOption(with: toReturn)
+            } */
+        }
+        return toReturn
+    }
 
     /// Specifies a timeout to apply to a connection attempt.
     //
@@ -254,6 +274,13 @@ extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
             return channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)
         }
         return .none
+    }
+}
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSConnectionBootstrap : NIOTCPOptionAppliable {
+    public func applyOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
+        return self.channelOption(option, value: value)
     }
 }
 #endif

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -246,7 +246,7 @@ extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
     /// Apply any understood shorthand options to the bootstrap, removing them from the set of options if they are consumed.
     /// - parameters:
     ///     - options:  The options to try applying - the options applied should be consumed from here.
-    /// - returns: The updated bootstrap with and options applied.
+    /// - returns: The updated bootstrap with any understood options applied.
     public func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> Self {
         var toReturn = self
         if options.consumeAllowLocalEndpointReuse().isSet {

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -247,9 +247,9 @@ extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
     /// - parameters:
     ///     - options:  The options to try applying - the options applied should be consumed from here.
     /// - returns: The updated bootstrap with and options applied.
-    public func _applyOptions(_ options: inout NIOTCPShorthandOptions) -> Self {
+    public func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> Self {
         var toReturn = self
-        if options.consumeAllowImmediateLocalEndpointAddressReuse().isSet {
+        if options.consumeAllowLocalEndpointReuse().isSet {
             toReturn = channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)
         }
         return toReturn

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -242,5 +242,18 @@ public final class NIOTSConnectionBootstrap {
 }
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {}
+extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
+    /// Apply a shorthand option to this bootstrap.
+    /// - parameters:
+    ///     - option:  The option to try applying.
+    /// - returns: The updated bootstrap if option was successfully applied, otherwise nil suggesting the caller try another method.
+    public func applyChannelOption(_ option: NIOTCPShorthandOption) -> Self? {
+        // Currently the only thing we have special action for is allowImmediateEndpointAddressReuse
+        // deal with that and let the default behaviour take care of everything else.
+        if option == NIOTCPShorthandOption.allowImmediateEndpointAddressReuse {
+            return channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)
+        }
+        return .none
+    }
+}
 #endif

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -250,7 +250,7 @@ extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
     public func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> Self {
         var toReturn = self
         if options.consumeAllowLocalEndpointReuse().isSet {
-            toReturn = channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)
+            toReturn = self.channelOption(NIOTSChannelOptions.allowLocalEndpointReuse, value: true)
         }
         return toReturn
     }

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -217,6 +217,9 @@ internal final class NIOTSConnectionChannel {
 
     /// The value of SO_REUSEPORT.
     private var reusePort = false
+    
+    /// The value of the allowLocalEndpointReuse option.
+    private var allowLocalEndpointReuse = false
 
     /// Whether to use peer-to-peer connectivity when connecting to Bonjour services.
     private var enablePeerToPeer = false
@@ -343,6 +346,8 @@ extension NIOTSConnectionChannel: Channel {
             }
         case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
             self.enablePeerToPeer = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
+        case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
+            self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
         default:
             fatalError("option \(type(of: option)).\(option) not supported")
         }
@@ -388,6 +393,8 @@ extension NIOTSConnectionChannel: Channel {
             return self.options.waitForActivity as! Option.Value
         case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
             return self.enablePeerToPeer as! Option.Value
+        case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
+            return self.allowLocalEndpointReuse as! Option.Value
         default:
             fatalError("option \(type(of: option)).\(option) not supported")
         }
@@ -466,8 +473,8 @@ extension NIOTSConnectionChannel: StateManagedChannel {
         let parameters = NWParameters(tls: self.tlsOptions, tcp: self.tcpOptions)
 
         // Network.framework munges REUSEADDR and REUSEPORT together, so we turn this on if we need
-        // either.
-        parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort
+        // either or it's been explicitly set.
+        parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort || self.allowLocalEndpointReuse
 
         parameters.includePeerToPeer = self.enablePeerToPeer
 

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -77,6 +77,9 @@ internal final class NIOTSListenerChannel {
 
     /// The value of SO_REUSEPORT.
     private var reusePort = false
+    
+    /// The value of the allowLocalEndpointReuse option.
+    private var allowLocalEndpointReuse = false
 
     /// Whether to enable peer-to-peer connectivity when using Bonjour services.
     private var enablePeerToPeer = false
@@ -195,6 +198,8 @@ extension NIOTSListenerChannel: Channel {
             }
         case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
             self.enablePeerToPeer = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
+        case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
+            self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
         default:
             fatalError("option \(option) not supported")
         }
@@ -232,6 +237,8 @@ extension NIOTSListenerChannel: Channel {
             }
         case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
             return self.enablePeerToPeer as! Option.Value
+        case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
+            return self.allowLocalEndpointReuse as! Option.Value
         default:
             fatalError("option \(option) not supported")
         }
@@ -310,7 +317,7 @@ extension NIOTSListenerChannel: StateManagedChannel {
 
         // Network.framework munges REUSEADDR and REUSEPORT together, so we turn this on if we need
         // either.
-        parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort
+        parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort || self.allowLocalEndpointReuse
 
         parameters.includePeerToPeer = self.enablePeerToPeer
 

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -316,7 +316,7 @@ extension NIOTSListenerChannel: StateManagedChannel {
         }
 
         // Network.framework munges REUSEADDR and REUSEPORT together, so we turn this on if we need
-        // either.
+        // either or it's been explicitly set.
         parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort || self.allowLocalEndpointReuse
 
         parameters.includePeerToPeer = self.enablePeerToPeer

--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -256,7 +256,7 @@ final class NIOTSBootstrapTests: XCTestCase {
         var optionValue : EventLoopFuture<Bool>? = nil
         let bootstrap = NIOClientTCPBootstrap(NIOTSConnectionBootstrap(group: group),
                                               tls: NIOInsecureNoTLS())
-            .channelOptions([.allowImmediateLocalEndpointAddressReuse])
+            .options([.allowImmediateLocalEndpointAddressReuse])
             .channelInitializer { channel in
                 optionValue = channel.getOption(NIOTSChannelOptions.allowLocalEndpointReuse)
                 return channel.eventLoop.makeSucceededFuture(())
@@ -268,16 +268,16 @@ final class NIOTSBootstrapTests: XCTestCase {
     }
     
     func testShorthandOptionsAreEquvalent() throws {
-        func setAndGetOption<Option>(option: Option, _ applyOptions : (NIOTSConnectionBootstrap) ->
-            NIOTSConnectionBootstrap) throws
-            -> Option.Value where Option : ChannelOption {
+        func setAndGetOption<Option>(option: Option, _ applyOptions : (NIOClientTCPBootstrap) ->
+                NIOClientTCPBootstrap) throws -> Option.Value where Option : ChannelOption {
             var optionRead : EventLoopFuture<Option.Value>?
             let group = NIOTSEventLoopGroup()
             let listenerChannel = try NIOTSListenerBootstrap(group: group)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
             
-            let bootstrap = applyOptions(NIOTSConnectionBootstrap(group: group))
+            let bootstrap = applyOptions(NIOClientTCPBootstrap(NIOTSConnectionBootstrap(group: group),
+                                                               tls: NIOInsecureNoTLS()))
                 .channelInitializer { channel in
                     optionRead = channel.getOption(option)
                     return channel.eventLoop.makeSucceededFuture(())
@@ -294,7 +294,7 @@ final class NIOTSBootstrapTests: XCTestCase {
                 bs.channelOption(longOption, value: setValue)
             }
             let shortSetValue = try setAndGetOption(option: longOption) { bs in
-                bs.channelOptions([shortOption])
+                bs.options([shortOption])
             }
             let unsetValue = try setAndGetOption(option: longOption) { $0 }
             

--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -256,7 +256,7 @@ final class NIOTSBootstrapTests: XCTestCase {
         var optionValue : EventLoopFuture<Bool>? = nil
         let bootstrap = NIOClientTCPBootstrap(NIOTSConnectionBootstrap(group: group),
                                               tls: NIOInsecureNoTLS())
-            .options([.allowImmediateLocalEndpointAddressReuse])
+            .channelConvenienceOptions([.allowLocalEndpointReuse])
             .channelInitializer { channel in
                 optionValue = channel.getOption(NIOTSChannelOptions.allowLocalEndpointReuse)
                 return channel.eventLoop.makeSucceededFuture(())
@@ -288,13 +288,13 @@ final class NIOTSBootstrapTests: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: NIOTCPShorthandOption) throws
+                                            shortOption: ChannelOptions.TCPConvenienceOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(option: longOption) { bs in
                 bs.channelOption(longOption, value: setValue)
             }
             let shortSetValue = try setAndGetOption(option: longOption) { bs in
-                bs.options([shortOption])
+                bs.channelConvenienceOptions([shortOption])
             }
             let unsetValue = try setAndGetOption(option: longOption) { $0 }
             
@@ -304,7 +304,7 @@ final class NIOTSBootstrapTests: XCTestCase {
         
         try checkOptionEquivalence(longOption: NIOTSChannelOptions.allowLocalEndpointReuse,
                                    setValue: true,
-                                   shortOption: .allowImmediateLocalEndpointAddressReuse)
+                                   shortOption: .allowLocalEndpointReuse)
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)

--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -256,7 +256,7 @@ final class NIOTSBootstrapTests: XCTestCase {
         var optionValue : EventLoopFuture<Bool>? = nil
         let bootstrap = NIOClientTCPBootstrap(NIOTSConnectionBootstrap(group: group),
                                               tls: NIOInsecureNoTLS())
-            .channelOptions([.allowImmediateEndpointAddressReuse])
+            .channelOptions([.allowImmediateLocalEndpointAddressReuse])
             .channelInitializer { channel in
                 optionValue = channel.getOption(NIOTSChannelOptions.allowLocalEndpointReuse)
                 return channel.eventLoop.makeSucceededFuture(())
@@ -304,7 +304,7 @@ final class NIOTSBootstrapTests: XCTestCase {
         
         try checkOptionEquivalence(longOption: NIOTSChannelOptions.allowLocalEndpointReuse,
                                    setValue: true,
-                                   shortOption: .allowImmediateEndpointAddressReuse)
+                                   shortOption: .allowImmediateLocalEndpointAddressReuse)
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)


### PR DESCRIPTION
Directly support the allowLocalEndpointReuse channel option including mapping from shorthand options.  Also add shorthand options for client.

### Motivation:

The NetworkFramework directly supports the concept of allowLocalEndPointReuse.  Currently to get through the nio system, this is mapped to the SO_REUSEADDR option.  

Now there is a shorthand option for this, it is sad to map from allowLocalEndPointReuse to SO_REUSEADDR and back again.

### Modifications:

Add a new NIOTS channel option for this setting.
Set the underlying based on any of new setting, reuseAddr or reusePort.
Add a override to interpret the shorthand option directly into the new option.
Add shorthand options for client with tests of equivalence to long options.

### Result:

Behaviour is identical but we can feel happier that the option mapping is less confusing.
