### PR TITLE
New channel options exposing properties of underlying NWConnection

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -25,16 +25,16 @@ public struct NIOTSChannelOptions {
     
     public static let currentPath = Types.NIOTSCurrentPathOption()
 
-    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-    public static let metadata = { (definition: NWProtocolDefinition) -> Types.NIOTSMetadataOption in
+    @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+    public static let metadata = { (definition: NWProtocolDefinition) -> NIOTSChannelOptions.Types.NIOTSMetadataOption in
         .init(definition: definition)
     }
 
-    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-    public static let establishmentReport = Types.NIOTSEstablishmentReportOption()
+    @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public static let establishmentReport = NIOTSChannelOptions.Types.NIOTSEstablishmentReportOption()
 
-    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-    public static let dataTransferReport = Types.NIOTSDataTransferReportOption()
+    @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public static let dataTransferReport = NIOTSChannelOptions.Types.NIOTSDataTransferReportOption()
 }
 
 
@@ -82,7 +82,7 @@ extension NIOTSChannelOptions {
         /// `NIOTSMetadataOption` accesses the metadata for a given `NWProtocol`.
         ///
         /// This option is only valid with `NIOTSConnectionBootstrap`.
-        @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
         public struct NIOTSMetadataOption: ChannelOption, Equatable {
             public typealias Value = NWProtocolMetadata
             
@@ -96,9 +96,9 @@ extension NIOTSChannelOptions {
         /// `NIOTSEstablishmentReportOption` accesses the `NWConnection.EstablishmentReport` of the underlying connection.
         ///
         /// This option is only valid with `NIOTSConnectionBootstrap`.
-        @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
         public struct NIOTSEstablishmentReportOption: ChannelOption, Equatable {
-            public typealias Value = NWConnection.EstablishmentReport
+            public typealias Value = EventLoopFuture<NWConnection.EstablishmentReport?>
             
             public init() {}
         }
@@ -106,7 +106,7 @@ extension NIOTSChannelOptions {
         /// `NIOTSDataTransferReportOption` accesses the `NWConnection.DataTransferReport` of the underlying connection.
         ///
         /// This option is only valid with `NIOTSConnectionBootstrap`.
-        @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
         public struct NIOTSDataTransferReportOption: ChannelOption, Equatable {
             public typealias Value = NWConnection.PendingDataTransferReport
             

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -25,7 +25,6 @@ public struct NIOTSChannelOptions {
     
     public static let currentPath = NIOTSChannelOptions.Types.NIOTSCurrentPathOption()
 
-    @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
     public static let metadata = { (definition: NWProtocolDefinition) -> NIOTSChannelOptions.Types.NIOTSMetadataOption in
         .init(definition: definition)
     }

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -23,7 +23,7 @@ public struct NIOTSChannelOptions {
 
     public static let enablePeerToPeer = NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption()
     
-    public static let currentPath = Types.NIOTSCurrentPathOption()
+    public static let currentPath = NIOTSChannelOptions.Types.NIOTSCurrentPathOption()
 
     @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
     public static let metadata = { (definition: NWProtocolDefinition) -> NIOTSChannelOptions.Types.NIOTSMetadataOption in

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 #if canImport(Network)
 import NIO
+import Network
 
 /// Options that can be set explicitly and only on bootstraps provided by `NIOTransportServices`.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
@@ -21,6 +22,19 @@ public struct NIOTSChannelOptions {
     public static let waitForActivity = NIOTSChannelOptions.Types.NIOTSWaitForActivityOption()
 
     public static let enablePeerToPeer = NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption()
+    
+    public static let currentPath = Types.NIOTSCurrentPathOption()
+
+    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    public static let metadata = { (definition: NWProtocolDefinition) -> Types.NIOTSMetadataOption in
+        .init(definition: definition)
+    }
+
+    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    public static let establishmentReport = Types.NIOTSEstablishmentReportOption()
+
+    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    public static let dataTransferReport = Types.NIOTSDataTransferReportOption()
 }
 
 
@@ -52,6 +66,50 @@ extension NIOTSChannelOptions {
         public struct NIOTSEnablePeerToPeerOption: ChannelOption, Equatable {
             public typealias Value = Bool
 
+            public init() {}
+        }
+        
+        /// `NIOTSCurrentPathOption` accesses the `NWConnection.currentPath` of the underlying connection.
+        ///
+        /// This option is only valid with `NIOTSConnectionBootstrap`.
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSCurrentPathOption: ChannelOption, Equatable {
+            public typealias Value = NWPath
+            
+            public init() {}
+        }
+        
+        /// `NIOTSMetadataOption` accesses the metadata for a given `NWProtocol`.
+        ///
+        /// This option is only valid with `NIOTSConnectionBootstrap`.
+        @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSMetadataOption: ChannelOption, Equatable {
+            public typealias Value = NWProtocolMetadata
+            
+            let definition: NWProtocolDefinition
+            
+            public init(definition: NWProtocolDefinition) {
+                self.definition = definition
+            }
+        }
+
+        /// `NIOTSEstablishmentReportOption` accesses the `NWConnection.EstablishmentReport` of the underlying connection.
+        ///
+        /// This option is only valid with `NIOTSConnectionBootstrap`.
+        @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSEstablishmentReportOption: ChannelOption, Equatable {
+            public typealias Value = NWConnection.EstablishmentReport
+            
+            public init() {}
+        }
+
+        /// `NIOTSDataTransferReportOption` accesses the `NWConnection.DataTransferReport` of the underlying connection.
+        ///
+        /// This option is only valid with `NIOTSConnectionBootstrap`.
+        @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSDataTransferReportOption: ChannelOption, Equatable {
+            public typealias Value = NWConnection.PendingDataTransferReport
+            
             public init() {}
         }
     }

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -426,6 +426,7 @@ extension NIOTSConnectionChannel: Channel {
     }
 }
 
+
 // MARK:- NIOTSConnectionChannel implementation of StateManagedChannel.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSConnectionChannel: StateManagedChannel {
@@ -455,7 +456,7 @@ extension NIOTSConnectionChannel: StateManagedChannel {
             self = .open
         }
     }
-    
+
     public func localAddress0() throws -> SocketAddress {
         guard let localEndpoint = self.nwConnection?.currentPath?.localEndpoint else {
             throw NIOTSErrors.NoCurrentPath()

--- a/Sources/NIOTransportServices/NIOTSErrors.swift
+++ b/Sources/NIOTransportServices/NIOTSErrors.swift
@@ -45,6 +45,10 @@ public enum NIOTSErrors {
     /// that channel has no path available. This can manifest, for example, when asking for remote
     /// or local addresses.
     public struct NoCurrentPath: NIOTSError { }
+    
+    /// `NoCurrentConnection` is thrown when an attempt is made to request connection details from a channel and
+    /// that channel has no connection available.
+    public struct NoCurrentConnection: NIOTSError { }
 
     /// `InvalidPort` is thrown when the port passed to a method is not valid.
     public struct InvalidPort: NIOTSError {

--- a/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
@@ -19,7 +19,7 @@ import NIOConcurrencyHelpers
 import NIOTransportServices
 import Network
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 class NIOTSChannelOptionsTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 
@@ -49,7 +49,6 @@ class NIOTSChannelOptionsTests: XCTestCase {
         XCTAssertEqual(currentPath.status, NWPath.Status.satisfied)
     }
     
-    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
     func testMetadata() throws {
         let listener = try NIOTSListenerBootstrap(group: self.group)
             .bind(host: "localhost", port: 0).wait()
@@ -68,7 +67,7 @@ class NIOTSChannelOptionsTests: XCTestCase {
         XCTAssertEqual(metadata.availableReceiveBuffer, 0)
     }
 
-    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func testEstablishmentReport() throws {
         let listener = try NIOTSListenerBootstrap(group: self.group)
             .bind(host: "localhost", port: 0).wait()
@@ -89,7 +88,7 @@ class NIOTSChannelOptionsTests: XCTestCase {
         XCTAssertEqual(establishmentReport!.resolutions.count, 0)
     }
     
-    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func testDataTransferReport() throws {
         let syncQueue = DispatchQueue(label: "syncQueue")
         let collectGroup = DispatchGroup()

--- a/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
@@ -83,8 +83,10 @@ class NIOTSChannelOptionsTests: XCTestCase {
             XCTAssertNoThrow(try connection.close().wait())
         }
         
-        let report = try connection.getOption(NIOTSChannelOptions.establishmentReport).wait()
-        XCTAssertEqual(report.resolutions.count, 0)
+        let reportFuture = try connection.getOption(NIOTSChannelOptions.establishmentReport).wait()
+        let establishmentReport = try reportFuture.wait()
+        
+        XCTAssertEqual(establishmentReport!.resolutions.count, 0)
     }
     
     @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
@@ -104,11 +106,9 @@ class NIOTSChannelOptionsTests: XCTestCase {
         
         let pendingReport = try connection.getOption(NIOTSChannelOptions.dataTransferReport).wait()
         
-        // okay this here does not work, obviously
-        
-        //  pendingReport.collect(queue: .main) { report in
-        //      XCTAssertEqual(report.pathReports.count, 1)
-        //  }
+        pendingReport.collect(queue: .main) { report in
+            XCTAssertEqual(report.pathReports.count, 1)
+        }
     }
 
 }

--- a/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+import XCTest
+import NIO
+import NIOConcurrencyHelpers
+import NIOTransportServices
+import Network
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+class NIOTSChannelOptionsTests: XCTestCase {
+    private var group: NIOTSEventLoopGroup!
+
+    override func setUp() {
+        self.group = NIOTSEventLoopGroup()
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    }
+    
+    func testCurrentPath() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connection = try NIOTSConnectionBootstrap(group: self.group)
+            .connect(to: listener.localAddress!)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try connection.close().wait())
+        }
+        
+        let currentPath = try connection.getOption(NIOTSChannelOptions.currentPath).wait()
+        XCTAssertEqual(currentPath.status, NWPath.Status.satisfied)
+    }
+    
+    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    func testMetadata() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connection = try NIOTSConnectionBootstrap(group: self.group)
+            .connect(to: listener.localAddress!)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try connection.close().wait())
+        }
+        
+        let metadata = try connection.getOption(NIOTSChannelOptions.metadata(NWProtocolTCP.definition)).wait() as! NWProtocolTCP.Metadata
+        XCTAssertEqual(metadata.availableReceiveBuffer, 0)
+    }
+
+    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    func testEstablishmentReport() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connection = try NIOTSConnectionBootstrap(group: self.group)
+            .connect(to: listener.localAddress!)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try connection.close().wait())
+        }
+        
+        let report = try connection.getOption(NIOTSChannelOptions.establishmentReport).wait()
+        XCTAssertEqual(report.resolutions.count, 0)
+    }
+    
+    @available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    func testDataTransferReport() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connection = try NIOTSConnectionBootstrap(group: self.group)
+            .connect(to: listener.localAddress!)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try connection.close().wait())
+        }
+        
+        let pendingReport = try connection.getOption(NIOTSChannelOptions.dataTransferReport).wait()
+        
+        // okay this here does not work, obviously
+        
+        //  pendingReport.collect(queue: .main) { report in
+        //      XCTAssertEqual(report.pathReports.count, 1)
+        //  }
+    }
+
+}
+#endif


### PR DESCRIPTION
This is a draft for implementing https://github.com/apple/swift-nio-transport-services/issues/88.

It adds new channel options in `NIOTSChannelOptions` and handles these in `getOption` of `NIOTSConnectionChannel`.

The collection of a `NWConnection.DataTransferReport` is not quite right in this implementation. I couldn't find a way to do it, so that part must probably be refactored. I posted what I have anyway, for sake of learning and discussion.