### PR TITLE
Update build_podspec.sh to not use exact dependency versions

### DIFF
--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -16,7 +16,7 @@
 set -eu
 
 function usage() {
-  echo "$0 [-u] version"
+  echo "$0 [-u] version nio_version"
   echo
   echo "OPTIONS:"
   echo "  -u: Additionally upload the podspec"
@@ -36,13 +36,25 @@ while getopts ":u" opt; do
 done
 shift "$((OPTIND-1))"
 
-if [[ $# -eq 0 ]]; then
-  echo "Must provide target version"
+if [[ $# -lt 2 ]]; then
+  usage
   exit 1
 fi
 
 version=$1
 NAME="SwiftNIOTransportServices"
+
+# Current SwiftNIO Version to add as dependency in the .podspec
+nio_version=$2
+if [[ $nio_version =~ ^([0-9]+)\. ]]; then
+  # Extract and incremenet the major version to use an upper bound on the
+  # version requirement (we can't use '~>' as it means 'up to the next
+  # major' if you specify x.y and 'up to the next minor' if you specify x.y.z).
+  next_major_version=$((${BASH_REMATCH[1]} + 1))
+else
+  echo "Invalid NIO version '$nio_version'"
+  exit 1
+fi
 
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tmpdir=$(mktemp -d /tmp/.build_podspecsXXXXXX)
@@ -67,15 +79,15 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '10.0'
 
   s.source_files = 'Sources/NIOTransportServices/**/*.swift'
-  s.dependency 'SwiftNIO', '~> 2.0'
-  s.dependency 'SwiftNIOFoundationCompat', '~> 2.0'
-  s.dependency 'SwiftNIOConcurrencyHelpers', '~> 2.0'
-  s.dependency 'SwiftNIOTLS', '~> 2.0'
+  s.dependency 'SwiftNIO', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOFoundationCompat', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOConcurrencyHelpers', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOTLS', '>= $nio_version', '< $next_major_version'
 end
 EOF
 
 if $upload; then
   echo "Uploading ${tmpdir}/${NAME}.podspec"
-  pod trunk push "${tmpdir}/${NAME}.podspec"
+  pod trunk push --synchronous "${tmpdir}/${NAME}.podspec"
 fi
 


### PR DESCRIPTION
Motivation:

The build_podspec.sh script generates a podspec which requires exact
versions of its dependencies. This very quickly turns into unresolvable
dependency graphs.

Modifications:

NIO version passed to script must be in the format MAJOR.MINOR
Podspec dependencies are now '>= MAJOR.MINOR', '< MAJOR+1'

Result:

Looser version requirements for podspecs
