### PR TITLE
silence #file to #filePath differently

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -21,11 +21,11 @@ import Network
 
 
 func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil,
-                               file: StaticString = (#file), line: UInt = #line) throws -> T {
+                               file: StaticString = #file, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {
-        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: file, line: line)
+        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: (file), line: line)
         if let defaultValue = defaultValue {
             return defaultValue
         } else {


### PR DESCRIPTION
Motivation:

only works if done when _calling_ a function, not when defining one :|.

- https://github.com/apple/swift/pull/32445
- https://bugs.swift.org/browse/SR-12936
- https://bugs.swift.org/browse/SR-12934
- https://bugs.swift.org/browse/SR-13041

Modifications:

Silence #file to #filePath differently.

Result:

Hopefully at some point we get this working.
