### PR TITLE
Update watchOS availability.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -81,7 +81,7 @@ extension NIOTSChannelOptions {
         /// `NIOTSMetadataOption` accesses the metadata for a given `NWProtocol`.
         ///
         /// This option is only valid with `NIOTSConnectionBootstrap`.
-        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
         public struct NIOTSMetadataOption: ChannelOption, Equatable {
             public typealias Value = NWProtocolMetadata
             


### PR DESCRIPTION
Motivation:

In a patch where we added some metadata options, we accidentally set the
availability wrong. This is a compile-time error, so we broke watchOS
compilation.

Modifications:

Update the availability of some types on watchOS.

Result:

Users can build on watchOS again.