### PR TITLE
Add docker config for swift-nio-transport-services

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+ARG swift_version=5.0
+ARG ubuntu_version=bionic
+ARG base_image=swift:$swift_version-$ubuntu_version
+FROM $base_image
+# needed to do again after FROM due to docker limitation
+ARG swift_version
+ARG ubuntu_version
+
+# set as UTF-8
+RUN apt-get update && apt-get install -y locales locales-all
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# tools
+RUN mkdir -p $HOME/.tools
+RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
+
+ARG swiftformat_version=0.40.12
+RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
+RUN cd $HOME/.tools/swift-format && swift build -c release
+RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-transport-services:18.04-5.0
+    build:
+      args:
+        ubuntu_version: "bionic"
+        swift_version: "5.0"
+
+  test:
+    image: swift-nio-transport-services:18.04-5.0
+
+  shell:
+    image: swift-nio:18.04-5.0

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,37 @@
+# this file is not designed to be run directly
+# instead, use the docker-compose.<os>.<swift> files
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1804.50.yaml run test
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-transport-services:default
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: swift-nio-transport-services:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ..:/code:z
+    working_dir: /code
+    cap_drop:
+      - CAP_NET_RAW
+      - CAP_NET_BIND_SERVICE
+
+  sanity:
+    <<: *common
+    command: /bin/bash -xcl "./scripts/sanity.sh"
+
+  test:
+    <<: *common
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+
+  # util
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

It's important that transport-services compiles and does nothing
on linux so it can be used in builds which just do the right thing
on all platforms.

Modifications:

Add basic docker-compose files based on those from swift-nio

Result:

It's possible to run docker on this repo to run the tests.