### PR TITLE
Fix docker shell to use correct image.

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -13,4 +13,4 @@ services:
     image: swift-nio-transport-services:18.04-5.0
 
   shell:
-    image: swift-nio:18.04-5.0
+    image: swift-nio-transport-services:18.04-5.0


### PR DESCRIPTION
Motivation:

Docker shell was incorrectly using the swift-nio docker image
rather than the swift-nio-transport-services one.

Modifications:

Change docker compose file to use the correct image.

Result:

Correct image will be used for docker shell.