### PR TITLE
Avoid crashing when connecting to empty host.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSErrors.swift
+++ b/Sources/NIOTransportServices/NIOTSErrors.swift
@@ -69,5 +69,10 @@ public enum NIOTSErrors {
             self.timeout = timeout
         }
     }
+
+    /// `InvalidHostname` is thrown when attempting to connect to an invalid host.
+    public struct InvalidHostname: NIOTSError {
+        public init() { }
+    }
 }
 #endif

--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -778,5 +778,12 @@ class NIOTSConnectionChannelTests: XCTestCase {
         // throw
         XCTAssertNoThrow(try eventPromise.futureResult.wait())
     }
+
+    func testConnectingToEmptyStringErrors() throws {
+        let connectBootstrap = NIOTSConnectionBootstrap(group: self.group)
+        XCTAssertThrowsError(try connectBootstrap.connect(host: "", port: 80).wait()) { error in
+            XCTAssertTrue(error is NIOTSErrors.InvalidHostname)
+        }
+    }
 }
 #endif


### PR DESCRIPTION
Motivation:

Network.framework will crash when we attempt to connect to the host
string "". That's not ideal, so we should detect that case and avoid it.

Modifications:

- Add code to detect the empty host string.

Result:

No crashes when accidentally connecting to "".