### PR TITLE
Remove a redundant availability check

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -407,7 +407,8 @@ extension NIOTSConnectionChannel: Channel {
             }
             return nwConnection.metadata(definition: optionValue.definition) as! Option.Value
         default:
-            if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            // watchOS 6.0 availability is covered by the @available on this extension.
+            if #available(OSX 10.15, iOS 13.0, tvOS 13.0, *) {
                 switch option {
                 case is NIOTSChannelOptions.Types.NIOTSEstablishmentReportOption:
                     guard let nwConnection = self.nwConnection else {


### PR DESCRIPTION
Motivation:

xcodebuild complains during Cocapods validation (which fails as a
result) about a redundant availability check. It's redundant because for
watchOS the availability guard on the outer scope has the same
conditions (for other platforms the conditions are tighter in the
inner scope). We never hit this before because we only recently added
watchOS to the supported platforms for Cocapods.

Modifications:

- Remove a redundant availability check

Result:

- Cocoapods can validate without error