### PR TITLE
Tolerate out-of-band ports.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -156,6 +156,11 @@ public final class NIOTSConnectionBootstrap {
     ///     - port: The port to connect to.
     /// - returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
     public func connect(host: String, port: Int) -> EventLoopFuture<Channel> {
+        let validPortRange = Int(UInt16.min)...Int(UInt16.max)
+        guard validPortRange.contains(port) else {
+            return self.group.next().makeFailedFuture(NIOTSErrors.InvalidPort(port: port))
+        }
+
         guard let actualPort = NWEndpoint.Port(rawValue: UInt16(port)) else {
             return self.group.next().makeFailedFuture(NIOTSErrors.InvalidPort(port: port))
         }

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -249,6 +249,11 @@ public final class NIOTSListenerBootstrap {
     ///     - host: The host to bind on.
     ///     - port: The port to bind on.
     public func bind(host: String, port: Int) -> EventLoopFuture<Channel> {
+        let validPortRange = Int(UInt16.min)...Int(UInt16.max)
+        guard validPortRange.contains(port) else {
+            return self.group.next().makeFailedFuture(NIOTSErrors.InvalidPort(port: port))
+        }
+
         return self.bind0 { (channel, promise) in
             do {
                 // NWListener does not actually resolve hostname-based NWEndpoints


### PR DESCRIPTION
Motivation:

We shouldn't crash if the user gives us a bad port.

Modifications:

- Check the ports are in-band before we move on.

Result:

We won't crash.
