### PR TITLE
Set the max bytes to be read from a connection

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -28,6 +28,8 @@ public struct NIOTSChannelOptions {
 
     public static let currentPath = NIOTSChannelOptions.Types.NIOTSCurrentPathOption()
 
+    public static let maxReceiveBytes = NIOTSChannelOptions.Types.NIOMaxReceiveBytesOption()
+
     public static let metadata = { (definition: NWProtocolDefinition) -> NIOTSChannelOptions.Types.NIOTSMetadataOption in
         .init(definition: definition)
     }
@@ -89,6 +91,13 @@ extension NIOTSChannelOptions {
         public struct NIOTSCurrentPathOption: ChannelOption, Equatable {
             public typealias Value = NWPath
             
+            public init() {}
+        }
+
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOMaxReceiveBytesOption: ChannelOption, Equatable {
+            public typealias Value = Int
+
             public init() {}
         }
         

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -34,6 +34,9 @@ private struct ConnectionChannelOptions {
 
     /// Whether this channel should wait for the connection to become active.
     internal var waitForActivity: Bool = true
+
+    // Maximum number of bytes read from a connection
+    internal var maxRecvBytes: Int = 8192
 }
 
 
@@ -321,6 +324,8 @@ extension NIOTSConnectionChannel: Channel {
             self.enablePeerToPeer = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
         case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
             self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
+        case _ as NIOTSChannelOptions.Types.NIOMaxReceiveBytesOption:
+            self.options.maxRecvBytes = value as! Int
         default:
             fatalError("option \(type(of: option)).\(option) not supported")
         }
@@ -571,7 +576,7 @@ extension NIOTSConnectionChannel: StateManagedChannel {
 
         // TODO: Can we do something sensible with these numbers?
         self.outstandingRead = true
-        conn.receive(minimumIncompleteLength: 1, maximumLength: 8192, completion: self.dataReceivedHandler(content:context:isComplete:error:))
+        conn.receive(minimumIncompleteLength: 1, maximumLength: self.options.maxRecvBytes, completion: self.dataReceivedHandler(content:context:isComplete:error:))
     }
 
     public func doClose0(error: Error) {


### PR DESCRIPTION
Add a `NIOTSChannelOption` to configure the maximum number of bytes to be read from a connection.

### Motivation:

Currently the max number of bytes is hard coded to 1KB. In some scenarios API consumers may want to change this to better suit their project. See also: #92

### Modifications:

- Added a new struct to `NIOTSChannelOptions.Types` to represent the new option
- Added a new property to `ConnectionChannelOptions` to store the default or configured value
- Use the stored value when reading from the connection

### Result:

- Nothing will change to existing setups
- A new option will be available to API consumers to configure the max bytes to be read from a connection
