### PR TITLE
Use non-deprecated API for removing handlers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
     ],
     targets: [
         .target(

--- a/Sources/NIOTransportServices/StateManagedChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedChannel.swift
@@ -225,7 +225,7 @@ extension StateManagedChannel {
             // Now we schedule our final cleanup. We need to keep the channel pipeline alive for at least one more event
             // loop tick, as more work might be using it.
             self.eventLoop.execute {
-                self.removeHandlers(channel: self)
+                self.removeHandlers(pipeline: self.pipeline)
                 self.closePromise.succeed(())
             }
 


### PR DESCRIPTION
Motivation:

`removeHandlers(channel:)` was deprecated in NIO 2.32.0.

Modifications:

- Raise minimum required NIO version to 2.32.0
- Use `removeHandlers(pipeline:)`

Result:

We don't use deprecated API.