### PR TITLE
Add platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-nio-transport-services",
+    platforms: [
+        .iOS(.v12),
+        .macOS(.v10_14),
+        .tvOS(.v12),
+        .watchOS(.v6)
+    ],
     products: [
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],


### PR DESCRIPTION
Add platform requirements to do release build in Apple platforms in Xcode 13.

### Motivation:

In Xcode 13 beta, Swift libraries fail to build for iOS targets that use armv7. 
This will affect to release build in Apple platforms.
<img width="1018" alt="Screen Shot 2021-08-27 at 13 14 42" src="https://user-images.githubusercontent.com/20222809/131070815-0dc02d77-7532-4854-a520-4124c7fe3936.png">

We can reproduce this issue on running archive build on NIOTransportServices scheme.

### Modifications:

As described in Xcode release note, just add `platforms:` in Package.swift. 

> Swift libraries may fail to build for iOS targets that use armv7. (74120874)
Workaround: Increase the platform dependency of the package to v12 or later.
https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes

This is caused by using Network.framework so platforms versions are depends on `Network.framework` availability.
The `platforms:` attribute will be ignored in Linux or Server Side Swift.

### Result:

Release build has succeeded.
