### PR TITLE
Explicitly retain timer source when scheduling tasks

### DIFF
--- a/Sources/NIOTransportServices/NIOTSEventLoop.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoop.swift
@@ -138,6 +138,12 @@ internal class NIOTSEventLoop: QoSEventLoop {
         }
         timerSource.resume()
 
+        // Create a retain cycle between the future and the timer source. This will be broken when the promise is
+        // completed by the event handler and this callback is run.
+        p.futureResult.whenComplete { _ in
+            timerSource.cancel()
+        }
+
         return Scheduled(promise: p, cancellationTask: {
             timerSource.cancel()
         })


### PR DESCRIPTION
Motivation:

When a task is scheduled using a `DispatchTimerSource` on a `NIOTSEventLoop`
the source is retain via a callback on the promise associated with the
scheduled task. This stops the source from deinit'd before the task is
run. However, the callback being added is an implementation details of
`Scheduled` and the retain cycle is incidental.

If that detail chnaged (such as in
https://github.com/apple/swift-nio/pull/2011) then tasks may not run and
the promise could be leaked.

Modifications:

- Explicitly add a retain cycle between the future and the timer source
  which is broken by the promise being completed and callbacks run.

Result:

The timer source is kept alive until the event fires.