### PR TITLE
Add 5.6 nightly CI

### DIFF
--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-transport-services:20.04-5.5
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.5"
+
+  test:
+    image: swift-nio-transport-services:20.04-5.5
+
+  shell:
+    image: swift-nio-transport-services:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-transport-services:20.04-5.6
+    build:
+      args:
+        ubuntu_version: "focal"
+        base_image: "swiftlang/swift:nightly-5.6-focal"
+
+  test:
+    image: swift-nio-transport-services:20.04-5.6
+
+  shell:
+    image: swift-nio-transport-services:20.04-5.6


### PR DESCRIPTION
The 5.6 nightly images are available, let's use them.

@tomerd Can you add a 5.6 builder here?