### PR TITLE
Update podspec script

### DIFF
--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -80,10 +80,19 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '6.0'
 
   s.source_files = 'Sources/NIOTransportServices/**/*.swift'
+  s.dependency 'CNIOAtomics', '>= $nio_version', '< $next_major_version'
+  s.dependency 'CNIODarwin', '>= $nio_version', '< $next_major_version'
+  s.dependency 'CNIOLinux', '>= $nio_version', '< $next_major_version'
+  s.dependency 'CNIOWindows', '>= $nio_version', '< $next_major_version'
   s.dependency 'SwiftNIO', '>= $nio_version', '< $next_major_version'
-  s.dependency 'SwiftNIOFoundationCompat', '>= $nio_version', '< $next_major_version'
   s.dependency 'SwiftNIOConcurrencyHelpers', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOConcurrencyHelpers', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOCore', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOEmbedded', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOFoundationCompat', '>= $nio_version', '< $next_major_version'
+  s.dependency 'SwiftNIOPosix', '>= $nio_version', '< $next_major_version'
   s.dependency 'SwiftNIOTLS', '>= $nio_version', '< $next_major_version'
+  s.dependency '_NIODataStructures', '>= $nio_version', '< $next_major_version'
 end
 EOF
 


### PR DESCRIPTION
Motivation:

To workaround https://github.com/apple/swift-nio/issues/2073 we must
list all transitive dependencies when building podspecs.

Modifications:

- Include transitive dependencies in the build_podspec script
- The list of dependencies was generated using
  the `list_transitive_dependencies.py` from the NIO repo.

Result:

Podspec generation script includes transitive dependencies.