### PR TITLE
Tweak testConnectingInvolvesWaiting to avoid invoking Private Relay

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -766,7 +766,7 @@ class NIOTSConnectionChannelTests: XCTestCase {
             .channelInitializer { channel in channel.pipeline.addHandler(eventRecordingHandler) }
             .connectTimeout(.seconds(5))  // This is the worst-case test time: normally it'll be faster as we don't wait for this.
 
-        let target = NWEndpoint.hostPort(host: "example.invalid", port: 80)
+        let target = NWEndpoint.hostPort(host: "example.invalid", port: 443)
 
         // We don't wait here, as the connect attempt should timeout. If it doesn't, we'll close it.
         connectBootstrap.connect(endpoint: target).whenSuccess { conn in


### PR DESCRIPTION
Motivation:

Private Relay kicks in to secure unencrypted data transfers, and
connections to port 80 are a good signal. As a result, the current
construction of this test will invoke Private Relay and attempt to route
over it.

While Private Relay is in beta this is a bad outcome, as it risks
causing bugs in unusual network scenarios. So let's tell Private Relay
we don't need it.

Modifications:

Pretend we're gonna connect to 443 instead.

Result:

More reliable test.