### PR TITLE
Don't close when waiting unless we were asked to.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -313,7 +313,7 @@ extension NIOTSConnectionChannel: Channel {
             let newValue = value as! Bool
             self.options.waitForActivity = newValue
 
-            if let state = self.nwConnection?.state, case .waiting(let err) = state {
+            if let state = self.nwConnection?.state, case .waiting(let err) = state, !newValue {
                 // We're in waiting now, so we should drop the connection.
                 self.close0(error: err, mode: .all, promise: nil)
             }


### PR DESCRIPTION
Motivation:

When we're waiting for connectivity, the user might tell us that they
aren't interested in waiting. In that case we take advantage of the
signal and close early.

However, the code as-written had a bug: we didn't care whether the user
told us they _didn't_ want to wait, or they _did_: we just closed
because they had an opinion! That's no good! We should only close if
they don't want to wait.

Modifications:

- Only close if the user doesn't want to wait.
- Add tests

Result:

We won't close if users don't want us to.
