### PR TITLE
Use `swift-atomics` instead of `NIOAtomics`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [
         .target(
@@ -30,8 +31,8 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
+                .product(name: "Atomics", package: "swift-atomics"),
             ]),
         .executableTarget(
             name: "NIOTSHTTPClient",
@@ -53,7 +54,7 @@ let package = Package(
                 "NIOTransportServices",
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
-                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "Atomics", package: "swift-atomics"),
             ]),
     ]
 )

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -19,6 +19,7 @@ import NIOFoundationCompat
 import NIOConcurrencyHelpers
 import Dispatch
 import Network
+import Atomics
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 internal final class NIOTSListenerChannel {
@@ -63,7 +64,7 @@ internal final class NIOTSListenerChannel {
     internal let supportedActivationType: ActivationType = .bind
 
     /// The active state, used for safely reporting the channel state across threads.
-    internal var isActive0: NIOAtomic<Bool> = .makeAtomic(value: false)
+    internal var isActive0 = ManagedAtomic(false)
 
     /// Whether a call to NWListener.receive has been made, but the completion
     /// handler has not yet been invoked.

--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Network)
+import Atomics
 import XCTest
 import Network
 import NIOCore
@@ -128,10 +129,10 @@ final class NIOTSBootstrapTests: XCTestCase {
         }
         let group = NIOTSEventLoopGroup()
         func makeServer(isTLS: EventLoopPromise<Bool>) throws -> Channel {
-            let numberOfConnections = NIOAtomic<Int>.makeAtomic(value: 0)
+            let numberOfConnections = ManagedAtomic(0)
             return try NIOTSListenerBootstrap(group: group)
                 .childChannelInitializer { channel in
-                    XCTAssertEqual(0, numberOfConnections.add(1))
+                    XCTAssertEqual(0, numberOfConnections.loadThenWrappingIncrement(ordering: .relaxed))
                     return channel.pipeline.addHandler(TellMeIfConnectionIsTLSHandler(isTLS: isTLS))
             }
             .bind(host: "127.0.0.1", port: 0)

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Network)
+import Atomics
 import XCTest
 import NIOCore
 import NIOConcurrencyHelpers
@@ -101,11 +102,11 @@ class NIOTSEventLoopTest: XCTestCase {
             weakELG = group
             weakEL = group.next()
 
-            let counter = NIOAtomic<Int>.makeAtomic(value: 0)
+            let counter = ManagedAtomic(0)
             let acceptedChan = group.next().makePromise(of: Channel.self)
             let server = try NIOTSListenerBootstrap(group: group)
                 .childChannelInitializer { channel in
-                    XCTAssertEqual(0, counter.add(1))
+                    XCTAssertEqual(0, counter.loadThenWrappingIncrement(ordering: .relaxed))
                     acceptedChan.succeed(channel)
                     return channel.eventLoop.makeSucceededFuture(())
                 }


### PR DESCRIPTION
`NIOAtomics` was deprecated in https://github.com/apple/swift-nio/pull/2204 in favor of `swift-atomics` https://github.com/apple/swift-atomics