### PR TITLE
Adopt `Sendable`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.41.1"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],

--- a/Sources/NIOTransportServices/NIOFilterEmptyWritesHandler.swift
+++ b/Sources/NIOTransportServices/NIOFilterEmptyWritesHandler.swift
@@ -85,6 +85,11 @@ public final class NIOFilterEmptyWritesHandler: ChannelDuplexHandler {
     }
 }
 
+#if swift(>=5.6)
+@available(*, unavailable)
+extension NIOFilterEmptyWritesHandler: Sendable {}
+#endif
+
 // Connection state management
 extension NIOFilterEmptyWritesHandler {
     public func channelActive(context: ChannelHandlerContext) {

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 #if canImport(Network)
 import NIOCore
+#if swift(>=5.6)
+@preconcurrency import Network
+#else
 import Network
+#endif
 
 /// Options that can be set explicitly and only on bootstraps provided by `NIOTransportServices`.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -238,6 +238,11 @@ public final class NIOTSConnectionBootstrap {
     }
 }
 
+#if swift(>=5.6)
+@available(*, unavailable)
+extension NIOTSConnectionBootstrap: Sendable {}
+#endif
+
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSConnectionBootstrap: NIOClientTCPBootstrapProtocol {
     /// Apply any understood shorthand options to the bootstrap, removing them from the set of options if they are consumed.

--- a/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
@@ -90,6 +90,11 @@ public final class NIOTSEventLoopGroup: EventLoopGroup {
     }
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSEventLoopGroup: @unchecked Sendable {}
+#endif
+
 /// A TLS provider to bootstrap TLS-enabled connections with `NIOClientTCPBootstrap`.
 ///
 /// Example:

--- a/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoopGroup.swift
@@ -90,11 +90,6 @@ public final class NIOTSEventLoopGroup: EventLoopGroup {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-extension NIOTSEventLoopGroup: @unchecked Sendable {}
-#endif
-
 /// A TLS provider to bootstrap TLS-enabled connections with `NIOClientTCPBootstrap`.
 ///
 /// Example:
@@ -124,4 +119,9 @@ public struct NIOTSClientTLSProvider: NIOClientTLSProvider {
         return bootstrap.tlsOptions(self.tlsOptions)
     }
 }
+#endif
+
+#if swift(>=5.5) && canImport(_Concurrency) && canImport(Network)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSEventLoopGroup: @unchecked Sendable {}
 #endif

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -346,7 +346,6 @@ public final class NIOTSListenerBootstrap {
     }
 }
 
-
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 private class AcceptHandler: ChannelInboundHandler {
     typealias InboundIn = NIOTSConnectionChannel

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -130,6 +130,10 @@ internal final class NIOTSListenerChannel {
     }
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSListenerChannel: @unchecked Sendable {}
+#endif
 
 // MARK:- NIOTSListenerChannel implementation of Channel
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -130,11 +130,6 @@ internal final class NIOTSListenerChannel {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-extension NIOTSListenerChannel: @unchecked Sendable {}
-#endif
-
 // MARK:- NIOTSListenerChannel implementation of Channel
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSListenerChannel: Channel {
@@ -498,4 +493,9 @@ extension NIOTSListenerChannel {
         return SynchronousOptions(channel: self)
     }
 }
+#endif
+
+#if swift(>=5.5) && canImport(_Concurrency) && canImport(Network)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSListenerChannel: @unchecked Sendable {}
 #endif

--- a/Sources/NIOTransportServices/NIOTSNetworkEvents.swift
+++ b/Sources/NIOTransportServices/NIOTSNetworkEvents.swift
@@ -13,14 +13,18 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Network)
+#if swift(>=5.6)
+@preconcurrency import Network
+#else
 import Network
+#endif
 import NIOCore
 
 /// A tag protocol that can be used to cover all network events emitted by `NIOTransportServices`.
 ///
 /// Users are strongly encouraged not to conform their own types to this protocol.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-public protocol NIOTSNetworkEvent: Equatable { }
+public protocol NIOTSNetworkEvent: Equatable, NIOPreconcurrencySendable { }
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 public enum NIOTSNetworkEvents {
@@ -98,4 +102,20 @@ public enum NIOTSNetworkEvents {
         }
     }
 }
+
+#if swift(>=5.6)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSNetworkEvents.BetterPathAvailable: Sendable {}
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSNetworkEvents.BetterPathUnavailable: Sendable {}
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSNetworkEvents.PathChanged: Sendable {}
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSNetworkEvents.ConnectToNWEndpoint: Sendable {}
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSNetworkEvents.BindToNWEndpoint: Sendable {}
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSNetworkEvents.WaitingForConnectivity: Sendable {}
+#endif
+
 #endif


### PR DESCRIPTION
Bumps `swift-nio` to `2.41.1` to have access to `NIOPreconcurrencySendable`.

`NIOTSMetadataOption` should probably be marked non-Sendable because it contains a reference type `NWProtocolDefinition` (and the Value of type `NWProtocolMetadata` is also a reference type). Network.framework has not adopted Sendable so it is hard to say if it is Sendable or not.  However, `NIOTSMetadataOption` conforms to `ChannelOption` which inherits from `NIOPreconcurrencySendable` and therefore must be `Sendable`. We will need to decided what we do with that type but that can be done separately.