### PR TITLE
Add missing availability annotation to NIOTSConnectionBootstrap

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -263,6 +263,7 @@ public final class NIOTSConnectionBootstrap {
 
 #if swift(>=5.6)
 @available(*, unavailable)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSConnectionBootstrap: Sendable {}
 #endif
 


### PR DESCRIPTION
Motivation:

- NIOTSConnectionBootstrap was extended to be marked as non-Sendable, this extenion missed the availability annotations.

Modifications:

- Add appropriate availability annotation

Result:

Resolves #159