### PR TITLE
Allow retrieval of metadata from `NWConnection`

### DIFF
--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -906,7 +906,7 @@ public struct NIOTSChannelIsNotATransportServicesChannel: Error, Hashable {
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSConnectionChannel {
     fileprivate func metadata(definition: NWProtocolDefinition) throws -> NWProtocolMetadata? {
-        guard let nwConnection = nwConnection else {
+        guard let nwConnection = self.nwConnection else {
             throw NIOTSConnectionNotInitialized()
         }
         return nwConnection.metadata(definition: definition)

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -899,7 +899,7 @@ public struct NIOTSConnectionNotInitialized: Error, Hashable {
     public init() {}
 }
 
-public struct NIOTSChannelIsNotATransportServicesChannel: Error, Hashable {
+public struct NIOTSChannelIsNotANIOTSConnectionChannel: Error, Hashable {
     public init() {}
 }
 
@@ -920,7 +920,7 @@ extension Channel {
     /// ``NIOTSChannelIsNotATransportServicesChannel`` or ``NIOTSConnectionNotInitialized``.
     public func getMetadata(definition: NWProtocolDefinition) -> EventLoopFuture<NWProtocolMetadata?> {
         guard let channel = self as? NIOTSConnectionChannel else {
-            return self.eventLoop.makeFailedFuture(NIOTSChannelIsNotATransportServicesChannel())
+            return self.eventLoop.makeFailedFuture(NIOTSChannelIsNotANIOTSConnectionChannel())
         }
         if self.eventLoop.inEventLoop {
             return self.eventLoop.makeCompletedFuture {
@@ -944,7 +944,7 @@ extension Channel {
     ) throws -> NWProtocolMetadata? {
         self.eventLoop.preconditionInEventLoop(file: file, line: line)
         guard let channel = self as? NIOTSConnectionChannel else {
-            throw NIOTSChannelIsNotATransportServicesChannel()
+            throw NIOTSChannelIsNotANIOTSConnectionChannel()
         }
         return try channel.metadata(definition: definition)
     }

--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -173,6 +173,7 @@ final class NIOTSBootstrapTests: XCTestCase {
             XCTFail("can't connect to server1")
             return
         }
+        XCTAssertNotNil(try client1.getMetadata(definition: NWProtocolTCP.definition).wait() as? NWProtocolTCP.Metadata)
         XCTAssertNoThrow(try client1.writeAndFlush(buffer).wait())
 
         // The TLS connection won't actually succeed but it takes Network.framework a while to tell us, we don't

--- a/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
@@ -28,11 +28,11 @@ final class NIOTSChannelMetadataTests: XCTestCase {
         defer { XCTAssertNoThrow(try listenerChannel.close().wait()) }
         
         XCTAssertThrowsError(try listenerChannel.getMetadata(definition: NWProtocolTLS.definition).wait()) { error in
-            XCTAssertTrue(error is NIOTSChannelIsNotATransportServicesChannel, "unexpected error \(error)")
+            XCTAssertTrue(error is NIOTSChannelIsNotANIOTSConnectionChannel, "unexpected error \(error)")
         }
         try! listenerChannel.eventLoop.submit {
             XCTAssertThrowsError(try listenerChannel.getMetadataSync(definition: NWProtocolTLS.definition)) { error in
-                XCTAssertTrue(error is NIOTSChannelIsNotATransportServicesChannel, "unexpected error \(error)")
+                XCTAssertTrue(error is NIOTSChannelIsNotANIOTSConnectionChannel, "unexpected error \(error)")
             }
         }.wait()
         

--- a/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+import Network
+import NIOCore
+import XCTest
+@testable import NIOTransportServices
+
+final class NIOTSChannelMetadataTests: XCTestCase {
+    func testThrowsIfCalledOnWrongChannel() throws {
+        let eventLoopGroup = NIOTSEventLoopGroup()
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let listenerBootsrap = NIOTSListenerBootstrap(group: eventLoopGroup)
+        let listenerChannel = try listenerBootsrap.bind(host: "localhost", port: 0).wait()
+        defer { XCTAssertNoThrow(try listenerChannel.close().wait()) }
+        
+        XCTAssertThrowsError(try listenerChannel.getMetadata(definition: NWProtocolTLS.definition).wait()) { error in
+            XCTAssertTrue(error is NIOTSChannelIsNotATransportServicesChannel, "unexpected error \(error)")
+        }
+        try! listenerChannel.eventLoop.submit {
+            XCTAssertThrowsError(try listenerChannel.getMetadataSync(definition: NWProtocolTLS.definition)) { error in
+                XCTAssertTrue(error is NIOTSChannelIsNotATransportServicesChannel, "unexpected error \(error)")
+            }
+        }.wait()
+        
+    }
+    func testThowsIfCalledOnANonInitializedChannel() {
+        let eventLoopGroup = NIOTSEventLoopGroup()
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let channel = NIOTSConnectionChannel(eventLoop: eventLoopGroup.next() as! NIOTSEventLoop, tcpOptions: .init(), tlsOptions: .init())
+        XCTAssertThrowsError(try channel.getMetadata(definition: NWProtocolTLS.definition).wait()) { error in
+            XCTAssertTrue(error is NIOTSConnectionNotInitialized, "unexpected error \(error)")
+        }
+        try! channel.eventLoop.submit {
+            XCTAssertThrowsError(try channel.getMetadataSync(definition: NWProtocolTLS.definition)) { error in
+                XCTAssertTrue(error is NIOTSConnectionNotInitialized, "unexpected error \(error)")
+            }
+        }.wait()
+    }
+}
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
@@ -18,6 +18,7 @@ import NIOCore
 import XCTest
 @testable import NIOTransportServices
 
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 final class NIOTSChannelMetadataTests: XCTestCase {
     func testThrowsIfCalledOnWrongChannel() throws {
         let eventLoopGroup = NIOTSEventLoopGroup()


### PR DESCRIPTION
### Motivation:

We want to log the TLS version in gRPC. To get at the TLS version if `NIOTS` is in use, we need to retrieve the `NWProtocolTLS.Metadata` from a  `NWConnection`.

### Modifications:

- add `Channel.getMetadata(definition:)` and `Channel.getMetadataSync(definition:)`

### Result:

Users outside of this library can now access metadata of an `NWConnection`.