### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -21,7 +21,7 @@ import Network
 
 
 func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil,
-                               file: StaticString = #filePa, line: UInt = #line) throws -> T {
+                               file: StaticString = #filePath, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {

--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -21,7 +21,7 @@ import Network
 
 
 func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil,
-                               file: StaticString = #file, line: UInt = #line) throws -> T {
+                               file: StaticString = #filePa, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath because of XCT Assertions
