### PR TITLE
Expose multicast service type

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -46,6 +46,9 @@ public struct NIOTSChannelOptions {
     /// See: ``Types/NIOTSDataTransferReportOption``.
     @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     public static let dataTransferReport = NIOTSChannelOptions.Types.NIOTSDataTransferReportOption()
+
+    /// See: ``Types/NIOTSMultipathOption``
+    public static let multipathServiceType = NIOTSChannelOptions.Types.NIOTSMultipathOption()
 }
 
 
@@ -133,6 +136,15 @@ extension NIOTSChannelOptions {
         public struct NIOTSDataTransferReportOption: ChannelOption, Equatable {
             public typealias Value = NWConnection.PendingDataTransferReport
             
+            public init() {}
+        }
+
+        /// ``NIOTSMultipathOption`` sets the multipath behaviour for a given `NWConnection`
+        /// or `NWListener`.
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSMultipathOption: ChannelOption, Equatable {
+            public typealias Value = NWParameters.MultipathServiceType
+
             public init() {}
         }
     }

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -85,6 +85,9 @@ internal final class NIOTSListenerChannel {
     /// Whether to enable peer-to-peer connectivity when using Bonjour services.
     private var enablePeerToPeer = false
 
+    /// The default multipath service type.
+    private var multipathServiceType = NWParameters.MultipathServiceType.disabled
+
     /// The event loop group to use for child channels.
     private let childLoopGroup: EventLoopGroup
 
@@ -220,6 +223,8 @@ extension NIOTSListenerChannel: Channel {
             self.enablePeerToPeer = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
         case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
             self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
+        case is NIOTSChannelOptions.Types.NIOTSMultipathOption:
+            self.multipathServiceType = value as! NIOTSChannelOptions.Types.NIOTSMultipathOption.Value
         default:
             fatalError("option \(option) not supported")
         }
@@ -257,6 +262,8 @@ extension NIOTSListenerChannel: Channel {
             return self.enablePeerToPeer as! Option.Value
         case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
             return self.allowLocalEndpointReuse as! Option.Value
+        case is NIOTSChannelOptions.Types.NIOTSMultipathOption:
+            return self.multipathServiceType as! Option.Value
         default:
             fatalError("option \(option) not supported")
         }
@@ -348,6 +355,8 @@ extension NIOTSListenerChannel: StateManagedChannel {
         parameters.allowLocalEndpointReuse = self.reuseAddress || self.reusePort || self.allowLocalEndpointReuse
 
         parameters.includePeerToPeer = self.enablePeerToPeer
+
+        parameters.multipathServiceType = self.multipathServiceType
 
         let listener: NWListener
         do {


### PR DESCRIPTION
Motivation

As we've rolled out support for multicast on Linux, it makes sense to add equivalent configuration for swift-nio-transport-services. The two features aren't one-to-one, as Network.framework has substantially more capability than the Linux functionality.

Modifications

- Expose a multipathServiceType channel option
- Add a test to confirm we use it properly

Result

Multicast service types are available.
