### PR TITLE
Drop Topics section

### DIFF
--- a/Sources/NIOTransportServices/Docs.docc/index.md
+++ b/Sources/NIOTransportServices/Docs.docc/index.md
@@ -69,38 +69,3 @@ SwiftNIO Extras     | Minimum Swift Version
 
 The legacy `swift-nio-transport-services` 0.x is part of the SwiftNIO 1 family of repositories and works with Swift 4.1 and newer. The source code can be found on the [`swift-nio-transport-services-swift-4-maintenance`](https://github.com/apple/swift-nio-transport-services/tree/swift-nio-transport-services-swift-4-maintenance) branch.
 
-## Topics
-
-### Event Loops and Groups
-
-- ``NIOTSEventLoopGroup``
-- ``QoSEventLoop``
-
-### Client Connections
-
-- ``NIOTSConnectionBootstrap``
-- ``NIOTSClientTLSProvider``
-
-### Server Connections
-
-- ``NIOTSListenerBootstrap``
-
-### Configuring Channels
-
-- ``NIOTSChannelOptions``
-- ``NIOTSEnablePeerToPeerOption``
-- ``NIOTSWaitForActivityOption``
-
-### Managing Channels
-
-- ``NIOTSNetworkEvents``
-- ``NIOTSNetworkEvent``
-
-### Errors
-
-- ``NIOTSErrors``
-- ``NIOTSError``
-
-### Channel Handlers
-
-- ``NIOFilterEmptyWritesHandler``


### PR DESCRIPTION
Motivation:

We try to support building our docs on Linux too, but that means we can't explicitly reference any symbols from `index.md`.

Modifications:

Enable CI-ing docs.

Result:

Docs will render on Linux too.
