### PR TITLE
Use underscore version of `NIOPreconcurrencySendable` to silence warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.51.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],

--- a/Sources/NIOTransportServices/NIOTSNetworkEvents.swift
+++ b/Sources/NIOTransportServices/NIOTSNetworkEvents.swift
@@ -20,7 +20,7 @@ import NIOCore
 ///
 /// Users are strongly encouraged not to conform their own types to this protocol.
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-public protocol NIOTSNetworkEvent: Equatable, NIOPreconcurrencySendable { }
+public protocol NIOTSNetworkEvent: Equatable, _NIOPreconcurrencySendable { }
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 public enum NIOTSNetworkEvents {


### PR DESCRIPTION
### Motivation
`swift-nio` has deprecated `NIOPreconcurrencySendable` in `2.51.0`. Removing the protocol conformance would be an API breaking change. Keeping the conformance is low cost and not worth the risk.

### Modifications
- replace `NIOPreconcurrencySendable` with underscore version `_NIOPreconcurrencySendable`

### Result
We compile again with the latest `swift-nio` release without warnings
