### PR TITLE
Adopt the `NIOAsyncChannel.Configuration`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -471,21 +471,14 @@ extension NIOTSConnectionBootstrap {
     /// - Parameters:
     ///   - host: The host to connect to.
     ///   - port: The port to connect to.
-    ///   - backpressureStrategy: The back pressure strategy used by the channel.
-    ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
-    ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
-    ///   - inboundType: The channel's inbound type.
-    ///   - outboundType: The channel's outbound type.
+    ///   - channelConfiguration: The channel's async channel configuration.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         host: String,
         port: Int,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isOutboundHalfClosureEnabled: Bool = false,
-        inboundType: Inbound.Type = Inbound.self,
-        outboundType: Outbound.Type = Outbound.self
+        channelConfiguration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
         try await self.connect(
             host: host,
@@ -494,10 +487,7 @@ extension NIOTSConnectionBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: backpressureStrategy,
-                    isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-                    inboundType: inboundType,
-                    outboundType: outboundType
+                    configuration: channelConfiguration
                 )
             }
         }
@@ -507,20 +497,13 @@ extension NIOTSConnectionBootstrap {
     ///
     /// - Parameters:
     ///   - address: The address to connect to.
-    ///   - backpressureStrategy: The back pressure strategy used by the channel.
-    ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
-    ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
-    ///   - inboundType: The channel's inbound type.
-    ///   - outboundType: The channel's outbound type.
+    ///   - channelConfiguration: The channel's async channel configuration.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         to address: SocketAddress,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isOutboundHalfClosureEnabled: Bool = false,
-        inboundType: Inbound.Type = Inbound.self,
-        outboundType: Outbound.Type = Outbound.self
+        channelConfiguration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
         try await self.connect(
             to: address
@@ -528,10 +511,7 @@ extension NIOTSConnectionBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: backpressureStrategy,
-                    isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-                    inboundType: inboundType,
-                    outboundType: outboundType
+                    configuration: channelConfiguration
                 )
             }
         }
@@ -541,20 +521,13 @@ extension NIOTSConnectionBootstrap {
     ///
     /// - Parameters:
     ///   - unixDomainSocketPath: The _Unix domain socket_ path to connect to.
-    ///   - backpressureStrategy: The back pressure strategy used by the channel.
-    ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
-    ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
-    ///   - inboundType: The channel's inbound type.
-    ///   - outboundType: The channel's outbound type.
+    ///   - channelConfiguration: The channel's async channel configuration.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         unixDomainSocketPath: String,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isOutboundHalfClosureEnabled: Bool = false,
-        inboundType: Inbound.Type = Inbound.self,
-        outboundType: Outbound.Type = Outbound.self
+        channelConfiguration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
         try await self.connect(
             unixDomainSocketPath: unixDomainSocketPath
@@ -562,10 +535,7 @@ extension NIOTSConnectionBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: backpressureStrategy,
-                    isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-                    inboundType: inboundType,
-                    outboundType: outboundType
+                    configuration: channelConfiguration
                 )
             }
         }
@@ -575,20 +545,13 @@ extension NIOTSConnectionBootstrap {
     ///
     /// - Parameters:
     ///   - endpoint: The endpoint to connect to.
-    ///   - backpressureStrategy: The back pressure strategy used by the channel.
-    ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
-    ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
-    ///   - inboundType: The channel's inbound type.
-    ///   - outboundType: The channel's outbound type.
+    ///   - channelConfiguration: The channel's async channel configuration.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         endpoint: NWEndpoint,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isOutboundHalfClosureEnabled: Bool = false,
-        inboundType: Inbound.Type = Inbound.self,
-        outboundType: Outbound.Type = Outbound.self
+        channelConfiguration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
         try await self.connect(
             endpoint: endpoint
@@ -596,10 +559,7 @@ extension NIOTSConnectionBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: backpressureStrategy,
-                    isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-                    inboundType: inboundType,
-                    outboundType: outboundType
+                    configuration: channelConfiguration
                 )
             }
         }
@@ -609,20 +569,13 @@ extension NIOTSConnectionBootstrap {
     ///
     /// - Parameters:
     ///   - connection: The `NWConnection` to wrap.
-    ///   - backpressureStrategy: The back pressure strategy used by the channel.
-    ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
-    ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
-    ///   - inboundType: The channel's inbound type.
-    ///   - outboundType: The channel's outbound type.
+    ///   - channelConfiguration: The channel's async channel configuration.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func withExistingNWConnection<Inbound: Sendable, Outbound: Sendable>(
         _ connection: NWConnection,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isOutboundHalfClosureEnabled: Bool = false,
-        inboundType: Inbound.Type = Inbound.self,
-        outboundType: Outbound.Type = Outbound.self
+        channelConfiguration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
         try await self.withExistingNWConnection(
             connection
@@ -630,10 +583,7 @@ extension NIOTSConnectionBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: backpressureStrategy,
-                    isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-                    inboundType: inboundType,
-                    outboundType: outboundType
+                    configuration: channelConfiguration
                 )
             }
         }

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -622,11 +622,7 @@ extension NIOTSListenerBootstrap {
     ///   - host: The host to bind on.
     ///   - port: The port to bind on.
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
-    ///   - childChannelBackpressureStrategy: The back pressure strategy used by the child channels.
-    ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
-    ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
-    ///   - childChannelInboundType: The child channel's inbound type.
-    ///   - childChannelOutboundType: The child channel's outbound type.
+    ///   - childChannelConfiguration: The child channel's async channel configuration.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
@@ -634,10 +630,7 @@ extension NIOTSListenerBootstrap {
         host: String,
         port: Int,
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        childChannelBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isChildChannelOutboundHalfClosureEnabled: Bool = false,
-        childChannelInboundType: ChildChannelInbound.Type = ChildChannelInbound.self,
-        childChannelOutboundType: ChildChannelOutbound.Type = ChildChannelOutbound.self
+        childChannelConfiguration: NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>, Never> {
         return try await self.bind(
             host: host,
@@ -647,10 +640,7 @@ extension NIOTSListenerBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: childChannelBackpressureStrategy,
-                    isOutboundHalfClosureEnabled: isChildChannelOutboundHalfClosureEnabled,
-                    inboundType: childChannelInboundType,
-                    outboundType: childChannelOutboundType
+                    configuration: childChannelConfiguration
                 )
             }
         }
@@ -661,21 +651,14 @@ extension NIOTSListenerBootstrap {
     /// - Parameters:
     ///   - address: The `SocketAddress` to bind on.
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
-    ///   - childChannelBackpressureStrategy: The back pressure strategy used by the child channels.
-    ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
-    ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
-    ///   - childChannelInboundType: The child channel's inbound type.
-    ///   - childChannelOutboundType: The child channel's outbound type.
+    ///   - childChannelConfiguration: The child channel's async channel configuration.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func bind<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         to address: SocketAddress,
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        childChannelBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isChildChannelOutboundHalfClosureEnabled: Bool = false,
-        childChannelInboundType: ChildChannelInbound.Type = ChildChannelInbound.self,
-        childChannelOutboundType: ChildChannelOutbound.Type = ChildChannelOutbound.self
+        childChannelConfiguration: NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>, Never> {
         return try await self.bind(
             to: address,
@@ -684,10 +667,7 @@ extension NIOTSListenerBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: childChannelBackpressureStrategy,
-                    isOutboundHalfClosureEnabled: isChildChannelOutboundHalfClosureEnabled,
-                    inboundType: childChannelInboundType,
-                    outboundType: childChannelOutboundType
+                    configuration: childChannelConfiguration
                 )
             }
         }
@@ -698,21 +678,14 @@ extension NIOTSListenerBootstrap {
     /// - Parameters:
     ///   - endpoint: The `NWEndpoint` to bind this channel to.
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
-    ///   - childChannelBackpressureStrategy: The back pressure strategy used by the child channels.
-    ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
-    ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
-    ///   - childChannelInboundType: The child channel's inbound type.
-    ///   - childChannelOutboundType: The child channel's outbound type.
+    ///   - childChannelConfiguration: The child channel's async channel configuration.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func bind<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         endpoint: NWEndpoint,
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        childChannelBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isChildChannelOutboundHalfClosureEnabled: Bool = false,
-        childChannelInboundType: ChildChannelInbound.Type = ChildChannelInbound.self,
-        childChannelOutboundType: ChildChannelOutbound.Type = ChildChannelOutbound.self
+        childChannelConfiguration: NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>, Never> {
         return try await self.bind(
             endpoint: endpoint,
@@ -721,10 +694,7 @@ extension NIOTSListenerBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: childChannelBackpressureStrategy,
-                    isOutboundHalfClosureEnabled: isChildChannelOutboundHalfClosureEnabled,
-                    inboundType: childChannelInboundType,
-                    outboundType: childChannelOutboundType
+                    configuration: childChannelConfiguration
                 )
             }
         }
@@ -735,21 +705,14 @@ extension NIOTSListenerBootstrap {
     /// - Parameters:
     ///   - listener: The NWListener to wrap.
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
-    ///   - childChannelBackpressureStrategy: The back pressure strategy used by the child channels.
-    ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
-    ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
-    ///   - childChannelInboundType: The child channel's inbound type.
-    ///   - childChannelOutboundType: The child channel's outbound type.
+    ///   - childChannelConfiguration: The child channel's async channel configuration.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
     public func withNWListener<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         _ listener: NWListener,
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        childChannelBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isChildChannelOutboundHalfClosureEnabled: Bool = false,
-        childChannelInboundType: ChildChannelInbound.Type = ChildChannelInbound.self,
-        childChannelOutboundType: ChildChannelOutbound.Type = ChildChannelOutbound.self
+        childChannelConfiguration: NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>.Configuration = .init()
     ) async throws -> NIOAsyncChannel<NIOAsyncChannel<ChildChannelInbound, ChildChannelOutbound>, Never> {
         return try await self.withNWListener(
             listener,
@@ -758,10 +721,7 @@ extension NIOTSListenerBootstrap {
             channel.eventLoop.makeCompletedFuture {
                 try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
-                    backpressureStrategy: childChannelBackpressureStrategy,
-                    isOutboundHalfClosureEnabled: isChildChannelOutboundHalfClosureEnabled,
-                    inboundType: childChannelInboundType,
-                    outboundType: childChannelOutboundType
+                    configuration: childChannelConfiguration
                 )
             }
         }

--- a/Tests/NIOTransportServicesTests/NIOTSAsyncBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSAsyncBootstrapTests.swift
@@ -192,8 +192,10 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             .bind(
                 host: "127.0.0.1",
                 port: 0,
-                childChannelInboundType: String.self,
-                childChannelOutboundType: String.self
+                childChannelConfiguration: .init(
+                    inboundType: String.self,
+                    outboundType: String.self
+                )
             )
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -512,8 +514,10 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             }
             .connect(
                 to: .init(ipAddress: "127.0.0.1", port: port),
-                inboundType: String.self,
-                outboundType: String.self
+                channelConfiguration: .init(
+                    inboundType: String.self,
+                    outboundType: String.self
+                )
             )
     }
 
@@ -610,11 +614,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 case "string":
                     return channel.eventLoop.makeCompletedFuture {
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                        let asyncChannel = try NIOAsyncChannel(
-                            synchronouslyWrapping: channel,
-                            isOutboundHalfClosureEnabled: true,
-                            inboundType: String.self,
-                            outboundType: String.self
+                        let asyncChannel: NIOAsyncChannel<String, String> = try NIOAsyncChannel(
+                            synchronouslyWrapping: channel
                         )
 
                         return NIOProtocolNegotiationResult.finished(NegotiationResult.string(asyncChannel))
@@ -623,11 +624,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     return channel.eventLoop.makeCompletedFuture {
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToByteHandler())
 
-                        let asyncChannel = try NIOAsyncChannel(
-                            synchronouslyWrapping: channel,
-                            isOutboundHalfClosureEnabled: true,
-                            inboundType: UInt8.self,
-                            outboundType: UInt8.self
+                        let asyncChannel: NIOAsyncChannel<UInt8, UInt8> = try NIOAsyncChannel(
+                            synchronouslyWrapping: channel
                         )
 
                         return NIOProtocolNegotiationResult.finished(NegotiationResult.byte(asyncChannel))


### PR DESCRIPTION
# Motivation
We introduced a new configuration struct for `NIOAsyncChannel` to make handling and configuring it easier.

# Modification
This PR adopts the new APIs.

# Result
Less boilerplate in our bootstrap methods