### PR TITLE
NIOSingletonsTransportServices: Use NIOTS in easy mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.57.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.58.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],

--- a/Sources/NIOTransportServices/NIOTSSingletons.swift
+++ b/Sources/NIOTransportServices/NIOTSSingletons.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+import NIOCore
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSEventLoopGroup {
+    /// A globally shared, lazily initialized, singleton ``NIOTSEventLoopGroup``.
+    ///
+    /// SwiftNIO allows and encourages the precise management of all operating system resources such as threads and file descriptors.
+    /// Certain resources (such as the main `EventLoopGroup`) however are usually globally shared across the program. This means
+    /// that many programs have to carry around an `EventLoopGroup` despite the fact they don't require the ability to fully return
+    /// all the operating resources which would imply shutting down the `EventLoopGroup`. This type is the global handle for singleton
+    /// resources that applications (and some libraries) can use to obtain never-shut-down singleton resources.
+    ///
+    /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
+    /// first use.
+    ///
+    /// The loop count of this group is determined by `NIOSingletons.groupLoopCountSuggestion`.
+    ///
+    /// - note: Users who do not want any code to spawn global singleton resources may set
+    ///         `NIOSingletons.singletonsEnabledSuggestion` to `false` which will lead to a forced crash
+    ///         if any code attempts to use the global singletons.
+    public static var singleton: NIOTSEventLoopGroup {
+        return NIOSingletons.transportServicesEventLoopGroup
+    }
+}
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension EventLoopGroup where Self == NIOTSEventLoopGroup {
+    /// A globally shared, lazily initialized, singleton ``NIOTSEventLoopGroup``.
+    ///
+    /// This provides the same object as ``NIOTSEventLoopGroup/singleton``.
+    public static var singletonNIOTSEventLoopGroup: Self {
+        return NIOTSEventLoopGroup.singleton
+    }
+}
+
+extension NIOSingletons {
+    /// A globally shared, lazily initialized, singleton ``NIOTSEventLoopGroup``.
+    ///
+    /// SwiftNIO allows and encourages the precise management of all operating system resources such as threads and file descriptors.
+    /// Certain resources (such as the main `EventLoopGroup`) however are usually globally shared across the program. This means
+    /// that many programs have to carry around an `EventLoopGroup` despite the fact they don't require the ability to fully return
+    /// all the operating resources which would imply shutting down the `EventLoopGroup`. This type is the global handle for singleton
+    /// resources that applications (and some libraries) can use to obtain never-shut-down singleton resources.
+    ///
+    /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
+    /// first use.
+    ///
+    /// The loop count of this group is determined by `NIOSingletons.groupLoopCountSuggestion`.
+    ///
+    /// - note: Users who do not want any code to spawn global singleton resources may set
+    ///         `NIOSingletons.singletonsEnabledSuggestion` to `false` which will lead to a forced crash
+    ///         if any code attempts to use the global singletons.
+    @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    public static var transportServicesEventLoopGroup: NIOTSEventLoopGroup {
+        return globalTransportServicesEventLoopGroup
+    }
+}
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+private let globalTransportServicesEventLoopGroup: NIOTSEventLoopGroup = {
+    guard NIOSingletons.singletonsEnabledSuggestion else {
+        fatalError("""
+                   Cannot create global singleton NIOThreadPool because the global singletons have been \
+                   disabled by setting `NIOSingletons.singletonsEnabledSuggestion = false`
+                   """)
+    }
+
+    let group = NIOTSEventLoopGroup._makePerpetualGroup(loopCount: NIOSingletons.groupLoopCountSuggestion,
+                                                        defaultQoS: .default)
+    _ = Unmanaged.passUnretained(group).retain() // Never gonna give you up, never gonna let you down.
+    return group
+}()
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -129,5 +129,25 @@ class NIOTSEventLoopTest: XCTestCase {
         XCTAssertNil(weakELG)
         XCTAssertNil(weakEL)
     }
+
+    func testGroupCanBeShutDown() async throws {
+        try await NIOTSEventLoopGroup(loopCount: 3).shutdownGracefully()
+    }
+
+    func testIndividualLoopsCannotBeShutDownWhenPartOfGroup() async throws {
+        let group = NIOTSEventLoopGroup(loopCount: 3)
+        defer {
+            try! group.syncShutdownGracefully()
+        }
+
+        for loop in group.makeIterator() {
+            do {
+                try await loop.shutdownGracefully()
+                XCTFail("this shouldn't work")
+            } catch {
+                XCTAssertEqual(.unsupportedOperation, error as? EventLoopError)
+            }
+        }
+    }
 }
 #endif

--- a/Tests/NIOTransportServicesTests/NIOTSSingletonTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSingletonTests.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+import XCTest
+import NIOTransportServices
+import NIOCore
+
+final class NIOSingletonsTests: XCTestCase {
+    func testNIOSingletonsTransportServicesEventLoopGroupWorks() async throws {
+        let works = try await NIOSingletons.transportServicesEventLoopGroup.any().submit { "yes" }.get()
+        XCTAssertEqual(works, "yes")
+    }
+
+    func testNIOTSEventLoopGroupSingletonWorks() async throws {
+        let works = try await NIOTSEventLoopGroup.singleton.any().submit { "yes" }.get()
+        XCTAssertEqual(works, "yes")
+        XCTAssert(NIOTSEventLoopGroup.singleton === NIOSingletons.transportServicesEventLoopGroup)
+    }
+
+    func testSingletonGroupCannotBeShutDown() async throws {
+        do {
+            try await NIOTSEventLoopGroup.singleton.shutdownGracefully()
+            XCTFail("shutdown worked, that's bad")
+        } catch {
+            XCTAssertEqual(EventLoopError.unsupportedOperation, error as? EventLoopError)
+        }
+    }
+
+    func testSingletonLoopThatArePartOfGroupCannotBeShutDown() async throws {
+        for loop in NIOTSEventLoopGroup.singleton.makeIterator() {
+            do {
+                try await loop.shutdownGracefully()
+                XCTFail("shutdown worked, that's bad")
+            } catch {
+                XCTAssertEqual(EventLoopError.unsupportedOperation, error as? EventLoopError)
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
### Motivation:

(companion PR to https://github.com/apple/swift-nio/pull/2471)

SwiftNIO allows and encourages to precisely manage all operating system resources like file descriptors & threads. That is a very important property of the system but in many places -- especially single Swift Concurrency arrived -- many simpler SwiftNIO programs only require a single, globally shared EventLoopGroup. Often even with just one thread.

Long story short: Many, probably most users would happily trade precise control over the threads for not having to pass around `EventLoopGroup`s. Today, many of those users resort to creating (and often leaking) threads because it's simpler. Adding singletons type which _lazily_ provide a singleton `EventLoopGroup` and an `NIOThreadPool` is IMHO a much better answer.

### Modifications:

- Add `NIOTSEventLoopGroup.singleton`
- Add `NIOSingletons.transportServicesEventLoopGroup`

### Result:

- Easier use of NIO that requires fewer parameters for users who don't require full control.
- Helps with https://github.com/apple/swift-nio/issues/2142