### PR TITLE
Adopt latest SPI(AsyncChannel) changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.57.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],


### PR DESCRIPTION
# Motivation
We introduced some breaking SPI(AsyncChannel) changes in NIO that we have to adopt here.

# Modification
This PR adopts the latest `NIOProtocolNegotiationResult` APIs. Additionally, it also drops all bind/connect methods on the bootstraps that are specific to protocol negotiation or `NIOAsyncChannel`.

# Result
Green CI on `main` and alignment between `NIOPosix` and `NIOTS.
