### PR TITLE
Fix 5.6 compiler error

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSAsyncBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSAsyncBootstrapTests.swift
@@ -185,7 +185,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             .bind(
                 host: "127.0.0.1",
                 port: 0
-            ) { channel in
+            ) { channel -> EventLoopFuture<NIOAsyncChannel<String, String>> in
                 channel.eventLoop.makeCompletedFuture {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))


### PR DESCRIPTION
# Motivation
After my recent PR we failed to compile on 5.6 since the compiler isn't capable to infer the return type of one of the closures.

# Modification
This PR adds the closure's return type explicitly.

# Result
Compiling on 5.6 again