### PR TITLE
Avoid race in datagram tests

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSDatagramConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSDatagramConnectionChannelTests.swift
@@ -67,10 +67,13 @@ final class ReadRecorder<DataType>: ChannelInboundHandler {
     var readWaiters: [Int: EventLoopPromise<[DataType]>] = [:]
     var readCompleteCount = 0
 
+    func handlerAdded(context: ChannelHandlerContext) {
+        self.loop = context.eventLoop
+    }
+
     func channelRegistered(context: ChannelHandlerContext) {
         XCTAssertEqual(.fresh, self.state)
         self.state = .registered
-        self.loop = context.eventLoop
     }
 
     func channelActive(context: ChannelHandlerContext) {


### PR DESCRIPTION
Motivation:

The datagram tests use a handler which sets its event loop in `channelRegistered`. A function on the handler is called which relies on the EL being set. However, this can race: the function can be called before `channelRegistered` is called.

Modifications:

- set the EL in `handlerAdded`

Result:

Fewer crashes