### PR TITLE
Fix a typo when casting the allowLocalEndpointReuse channel option value

### DIFF
--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -240,7 +240,7 @@ extension StateManagedListenerChannel {
         case is NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption:
             self.enablePeerToPeer = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
         case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
-            self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
+            self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse.Value
         case is NIOTSChannelOptions.Types.NIOTSMultipathOption:
             self.multipathServiceType = value as! NIOTSChannelOptions.Types.NIOTSMultipathOption.Value
         default:

--- a/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
@@ -538,7 +538,7 @@ extension StateManagedNWConnectionChannel {
         case _ as ChannelOptions.Types.AllowRemoteHalfClosureOption:
             self.options.supportRemoteHalfClosure = value as! Bool
         case is NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse:
-            self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSEnablePeerToPeerOption.Value
+            self.allowLocalEndpointReuse = value as! NIOTSChannelOptions.Types.NIOTSAllowLocalEndpointReuse.Value
         default:
             try self.setChannelSpecificOption0(option: option, value: value)
         }


### PR DESCRIPTION
This PR addresses issue #133.

### Motivation:

There was a typo when setting the allowLocalEndpointReuse channel option, where it was cast to NIOTSEnablePeerToPeerOption.Value instead of NIOTSAllowLocalEndpointReuse.Value. Both of these types are Bools, so this wouldn't cause any actual issues, this change is to more to keep the code consistent, and reduce confusion for future contributors or others reading the code base.

### Modifications:

This commit casts the allowLocalEndpointReuse property in StateManagedListenerChannel and StateManagedNWConnectionChannel.

### Result:

The typo is fixed after this change.
