### PR TITLE
Support setting the Bonjour service TXT record.

### DIFF
--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 #if canImport(Network)
+import Foundation
 import NIOCore
 @preconcurrency import Network
 
@@ -45,6 +46,13 @@ public struct NIOTSChannelOptions {
 
     /// See: ``Types/NIOTSMultipathOption``
     public static let multipathServiceType = NIOTSChannelOptions.Types.NIOTSMultipathOption()
+
+    /// See: ``Types/NIOTSServiceTXTRecordObjectOption``
+    @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public static let serviceTXTRecordObject = NIOTSChannelOptions.Types.NIOTSServiceTXTRecordObjectOption()
+
+    /// See: ``Types/NIOTSServiceTXTRecordOption``
+    public static let serviceTXTRecord = NIOTSChannelOptions.Types.NIOTSServiceTXTRecordOption()
 }
 
 
@@ -140,6 +148,24 @@ extension NIOTSChannelOptions {
         @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
         public struct NIOTSMultipathOption: ChannelOption, Equatable {
             public typealias Value = NWParameters.MultipathServiceType
+
+            public init() {}
+        }
+
+        /// ``NIOTSServiceTXTRecordObjectOption`` gets/sets the TXT record object for the `NWListener.Service`. The TXT
+        /// record is a dictionary of arbitrary metadata that can be included in the advertisement of a Bonjour service.
+        @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+        public struct NIOTSServiceTXTRecordObjectOption: ChannelOption, Equatable {
+            public typealias Value = NWTXTRecord?
+
+            public init() {}
+        }
+
+        /// ``NIOTSServiceTXTRecordOption`` gets/sets the TXT record data for the `NWListener.Service`. The TXT record
+        /// is a dictionary of arbitrary metadata that can be included in the advertisement of a Bonjour service.
+        @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+        public struct NIOTSServiceTXTRecordOption: ChannelOption, Equatable {
+            public typealias Value = Data?
 
             public init() {}
         }


### PR DESCRIPTION
Add a `NIOTSChannelOption` to configure the Bonjour service TXT record.

### Motivation:

Some users may want to set or modify the advertised TXT record when publishing a Bonjour service.

### Modifications:

Expose setting the Bonjour TXT record via new channel options. An option for setting an `NWTXTRecord` was added. This object allows for easily manipulating a TXT record, but is only available starting in `MacOS 10.15`, `iOS 13`, `tvOS 13`, and `WatchOS 6.0`, so an additional channel option has also been added to support setting the TXT record on lower OS versions.

### Result:

Nothing will change for existing users, but this change allows users to be able set or modify the Bonjour service TXT record.
