### PR TITLE
Implement customization point for `enqueue`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.58.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.60.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -19,9 +19,20 @@ import NIOCore
 import NIOConcurrencyHelpers
 import NIOTransportServices
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+private final actor CustomActor {
+    let executor = NIOTSEventLoopGroup(loopCount: 1).next().executor
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        return executor.asUnownedSerialExecutor()
+    }
+
+    func foo() -> String {
+        return "foo"
+    }
+}
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
-class NIOTSEventLoopTest: XCTestCase {
+final class NIOTSEventLoopTest: XCTestCase {
     func testIsInEventLoopWorks() throws {
         let group = NIOTSEventLoopGroup()
         let loop = group.next()
@@ -148,6 +159,13 @@ class NIOTSEventLoopTest: XCTestCase {
                 XCTAssertEqual(.unsupportedOperation, error as? EventLoopError)
             }
         }
+    }
+
+    @available(macOS 14.0, iOS 17.0, tvOS 17.0, *)
+    func testSerialExecutor() async {
+        let actor = CustomActor()
+        let result = await actor.foo()
+        XCTAssertEqual(result, "foo")
     }
 }
 #endif


### PR DESCRIPTION
# Motivation
The default implementation of `SerialExecutor` for `EventLoop`s causes a lot of allocations that's why we added a new customization point to allow `EventLoop`s to implement fast paths.

# Modification
This PR adds the customization point to `NIOTSEventLoop`.