### PR TITLE
Make tests less flaky

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSAsyncBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSAsyncBootstrapTests.swift
@@ -222,9 +222,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             let stringChannel = try await self.makeClientChannel(eventLoopGroup: eventLoopGroup, port: channel.channel.localAddress!.port!)
             try await stringChannel.executeThenClose { _, outbound in
                 try await outbound.write("hello")
+                await XCTAsyncAssertEqual(await iterator.next(), .string("hello"))
             }
-
-            await XCTAsyncAssertEqual(await iterator.next(), .string("hello"))
 
             group.cancelAll()
         }
@@ -287,8 +286,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await stringChannel.executeThenClose { _, outbound in
                     try await outbound.write("hello")
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -305,8 +304,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await byteChannel.executeThenClose { _, outbound in
                     try await outbound.write(UInt8(8))
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
             }
 
             group.cancelAll()
@@ -371,8 +370,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await stringChannel.executeThenClose { _, outbound in
                     try await outbound.write("hello")
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -388,8 +387,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await stringChannel.executeThenClose { _, outbound in
                     try await outbound.write("hello")
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -407,8 +406,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await byteChannel.executeThenClose { _, outbound in
                     try await outbound.write(UInt8(8))
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
             }
 
             let stringByteNegotiationResult = try await self.makeClientChannelWithNestedProtocolNegotiation(
@@ -424,8 +423,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await byteChannel.executeThenClose { _, outbound in
                     try await outbound.write(UInt8(8))
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
             }
 
             group.cancelAll()
@@ -522,8 +521,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 // This is the actual content
                 try await stringChannel.executeThenClose { _, outbound in
                     try await outbound.write("hello")
+                    await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
             case .byte:
                 preconditionFailure()
             }


### PR DESCRIPTION
# Motivation
After the recent changes in NIO where we introduced the `executeThenClose` method on the `NIOAsyncChannel` our tests here became flaky since we were waiting for something to happen but potentially closed the client channels before we wrote out the data.

# Modification
This PR makes sure we are awaiting for the event in the `executeThenClose` scope; hence, making sure we are not closing the client channels too early.

# Result
Less flakey tests.