### PR TITLE
Fix availability guards and compiler warnings

### DIFF
--- a/Sources/NIOTSHTTPClient/main.swift
+++ b/Sources/NIOTSHTTPClient/main.swift
@@ -57,7 +57,7 @@ final class HTTP1ClientHandler: ChannelInboundHandler {
     }
 }
 
-if #available(OSX 10.14, *) {
+if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
     let group = NIOTSEventLoopGroup()
     let channel = try! NIOTSConnectionBootstrap(group: group)
         .connectTimeout(.hours(1))

--- a/Sources/NIOTSHTTPServer/main.swift
+++ b/Sources/NIOTSHTTPServer/main.swift
@@ -18,7 +18,7 @@ import NIOTransportServices
 import NIOHTTP1
 import Network
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 final class HTTP1ServerHandler: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
@@ -37,7 +37,7 @@ final class HTTP1ServerHandler: ChannelInboundHandler {
     }
 }
 
-if #available(OSX 10.14, *) {
+if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
     let group = NIOTSEventLoopGroup()
     let channel = try! NIOTSListenerBootstrap(group: group)
         .childChannelInitializer { channel in


### PR DESCRIPTION
# Motivation
We missed a few availability guards in our tests which caused errors when compiling for older Darwin platforms.

# Modification
This PR adds the missing guards.

# Result
We should build on all supported platforms again
