### PR TITLE
Fix build on watchOS

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -22,7 +22,7 @@ import NIOTransportServices
 import NIOConcurrencyHelpers
 import Foundation
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 final class NIOTSBootstrapTests: XCTestCase {
     var groupBag: [NIOTSEventLoopGroup]? = nil // protected by `self.lock`
     let lock = NIOLock()

--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -20,7 +20,7 @@ import NIOTransportServices
 import Foundation
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 final class ConnectRecordingHandler: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
@@ -70,7 +70,7 @@ final class WritabilityChangedHandler: ChannelInboundHandler {
 }
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 final class DisableWaitingAfterConnect: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
@@ -86,7 +86,7 @@ final class DisableWaitingAfterConnect: ChannelOutboundHandler {
     }
 }
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 final class EnableWaitingAfterWaiting: ChannelInboundHandler {
     typealias InboundIn = Any
     typealias InboundOut = Any
@@ -137,7 +137,7 @@ final class EventWaiter<Event>: ChannelInboundHandler {
 }
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 class NIOTSConnectionChannelTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 

--- a/Tests/NIOTransportServicesTests/NIOTSDatagramConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSDatagramConnectionChannelTests.swift
@@ -109,7 +109,7 @@ final class ReadRecorder<DataType>: ChannelInboundHandler {
 }
 
 // Mimicks the DatagramChannelTest from apple/swift-nio
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 final class NIOTSDatagramConnectionChannelTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 

--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -198,7 +198,7 @@ extension ByteBufferAllocator {
     }
 }
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 class NIOTSEndToEndTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 

--- a/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEventLoopTests.swift
@@ -20,7 +20,7 @@ import NIOConcurrencyHelpers
 import NIOTransportServices
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 class NIOTSEventLoopTest: XCTestCase {
     func testIsInEventLoopWorks() throws {
         let group = NIOTSEventLoopGroup()

--- a/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSListenerChannelTests.swift
@@ -19,7 +19,7 @@ import NIOCore
 import NIOTransportServices
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 final class BindRecordingHandler: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
@@ -44,7 +44,7 @@ final class BindRecordingHandler: ChannelOutboundHandler {
 }
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 class NIOTSListenerChannelTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionTests.swift
@@ -19,7 +19,7 @@ import Network
 @testable import NIOTransportServices
 
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 class NIOTSSocketOptionTests: XCTestCase {
     private var options: NWProtocolTCP.Options!
 

--- a/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSSocketOptionsOnChannelTests.swift
@@ -47,7 +47,7 @@ private extension Channel {
     }
 }
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6, *)
 class NIOTSSocketOptionsOnChannelTests: XCTestCase {
     private var group: NIOTSEventLoopGroup!
 


### PR DESCRIPTION
### Motivation:

This project doesn't currently build for watchOS because the availability guards are missing for watchOS.

### Modifications:

Extend the availability guards to include watchOS.

### Result:

Can build for watchOS.