### PR TITLE
Fix the syncOptions on most channels

### DIFF
--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramBootstrap.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramBootstrap.swift
@@ -152,7 +152,7 @@ public final class NIOTSDatagramBootstrap {
     /// - returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
     public func connect(to address: SocketAddress) -> EventLoopFuture<Channel> {
         return self.connect0 { channel, promise in
-            channel.bind(to: address, promise: promise)
+            channel.connect(to: address, promise: promise)
         }
     }
 

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
@@ -187,4 +187,27 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
         self.connection = connection
     }
 }
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+extension NIOTSDatagramChannel {
+    internal struct SynchronousOptions: NIOSynchronousChannelOptions {
+        private let channel: NIOTSDatagramChannel
+
+        fileprivate init(channel: NIOTSDatagramChannel) {
+            self.channel = channel
+        }
+
+        public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
+            try self.channel.setOption0(option: option, value: value)
+        }
+
+        public func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
+            return try self.channel.getOption0(option: option)
+        }
+    }
+
+    public var syncOptions: NIOSynchronousChannelOptions? {
+        return SynchronousOptions(channel: self)
+    }
+}
 #endif

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramListenerChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramListenerChannel.swift
@@ -127,10 +127,7 @@ internal final class NIOTSDatagramListenerChannel: StateManagedListenerChannel<N
         self.pipeline.fireChannelRead(NIOAny(newChannel))
         self.pipeline.fireChannelReadComplete()
     }
-}
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-extension NIOTSDatagramListenerChannel {
     internal struct SynchronousOptions: NIOSynchronousChannelOptions {
         private let channel: NIOTSDatagramListenerChannel
 
@@ -147,7 +144,7 @@ extension NIOTSDatagramListenerChannel {
         }
     }
 
-    public var syncOptions: NIOSynchronousChannelOptions? {
+    public override var syncOptions: NIOSynchronousChannelOptions? {
         return SynchronousOptions(channel: self)
     }
 }

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -129,10 +129,7 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
         self.pipeline.fireChannelRead(NIOAny(newChannel))
         self.pipeline.fireChannelReadComplete()
     }
-}
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-extension NIOTSListenerChannel {
     internal struct SynchronousOptions: NIOSynchronousChannelOptions {
         private let channel: NIOTSListenerChannel
 
@@ -149,7 +146,7 @@ extension NIOTSListenerChannel {
         }
     }
 
-    public var syncOptions: NIOSynchronousChannelOptions? {
+    public override var syncOptions: NIOSynchronousChannelOptions? {
         return SynchronousOptions(channel: self)
     }
 }

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -170,6 +170,13 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     func newConnectionHandler(connection: NWConnection) {
         fatalError("This function must be overridden by the subclass")
     }
+
+    // This needs to be declared here to make sure the child classes can override
+    // the behaviour.
+    internal var syncOptions: NIOSynchronousChannelOptions? {
+        return nil
+    }
+
 }
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)


### PR DESCRIPTION
Motivation:

Looks like when we previously added syncOptions support to our channels, we had a few issues. The listeners had code added, but the code never worked. This is because the code was defined in subclasses, but the protocol conformance comes from the parent class, and that parent class did not have a customized protocol witness.

The datagram channel was also entirely missing its support.

Modifications:

- Added the missing unit tests for sync options.
- Added syncOptions to StateManagedListenerChannel base class.
- Added overrides to the listener subclasses.
- Added syncOptions to datagram channel

Result:

Sync options actually work across the board.
