### PR TITLE
Add ChannelOptions to extract base types.

### DIFF
--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
@@ -150,6 +150,16 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
     }
 
     func getChannelSpecificOption0<Option>(option: Option) throws -> Option.Value where Option : ChannelOption {
+        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+            switch option {
+            case is NIOTSChannelOptions.Types.NIOTSConnectionOption:
+                return self.connection as! Option.Value
+            default:
+                // Check the non-constrained options.
+                ()
+            }
+        }
+
         fatalError("option \(type(of: option)).\(option) not supported")
     }
 

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -45,6 +45,14 @@ public struct NIOTSChannelOptions {
 
     /// See: ``Types/NIOTSMultipathOption``
     public static let multipathServiceType = NIOTSChannelOptions.Types.NIOTSMultipathOption()
+
+    /// See: ``Types/NIOTSConnectionOption``.
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    public static let connection = NIOTSChannelOptions.Types.NIOTSConnectionOption()
+
+    /// See: ``Types/NIOTSListenerOption``.
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    public static let listener = NIOTSChannelOptions.Types.NIOTSListenerOption()
 }
 
 
@@ -140,6 +148,34 @@ extension NIOTSChannelOptions {
         @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
         public struct NIOTSMultipathOption: ChannelOption, Equatable {
             public typealias Value = NWParameters.MultipathServiceType
+
+            public init() {}
+        }
+
+        /// ``NIOTSConnectionOption`` accesses the `NWConnection` of the underlying connection.
+        ///
+        /// > Warning: Callers must be extremely careful with this option, as it is easy to break an existing
+        /// > connection that uses it. NIOTS doesn't support arbitrary modifications of the `NWConnection`
+        /// > underlying a `Channel`.
+        ///
+        /// This option is only valid with a `Channel` backed by an `NWConnection`.
+        @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+        public struct NIOTSConnectionOption: ChannelOption, Equatable {
+            public typealias Value = NWConnection?
+
+            public init() {}
+        }
+
+        /// ``NIOTSListenerOption`` accesses the `NWListener` of the underlying connection.
+        ///
+        /// > Warning: Callers must be extremely careful with this option, as it is easy to break an existing
+        /// > connection that uses it. NIOTS doesn't support arbitrary modifications of the `NWListener`
+        /// > underlying a `Channel`.
+        ///
+        /// This option is only valid with a `Channel` backed by an `NWListener`.
+        @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+        public struct NIOTSListenerOption: ChannelOption, Equatable {
+            public typealias Value = NWListener?
 
             public init() {}
         }

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -264,6 +264,16 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSConnectionChannel: Channel {
     func getChannelSpecificOption0<Option>(option: Option) throws -> Option.Value where Option : ChannelOption {
+        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+            switch option {
+            case is NIOTSChannelOptions.Types.NIOTSConnectionOption:
+                return self.connection as! Option.Value
+            default:
+                // Fallthrough to non-restricted options.
+                ()
+            }
+        }
+
         switch option {
         case is NIOTSChannelOptions.Types.NIOTSMultipathOption:
             return self.multipathServiceType as! Option.Value

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -270,6 +270,16 @@ extension StateManagedListenerChannel {
             throw ChannelError.ioOnClosedChannel
         }
 
+        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+            switch option {
+            case is NIOTSChannelOptions.Types.NIOTSListenerOption:
+                return self.nwListener as! Option.Value
+            default:
+                // Fallthrough to non-restricted options
+                ()
+            }
+        }
+
         switch option {
         case is ChannelOptions.Types.AutoReadOption:
             return autoRead as! Option.Value


### PR DESCRIPTION
Motivation:

In some cases users may want to access APIs we haven't exposed in NIOTransportServices. We should have a fallback that allows users to do this.

Modifications:

- Add ChannelOptions for getting NWConnection and NWListener.

Result:

Users have an escape hatch
