### PR TITLE
We no longer require the docc plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -18,6 +18,9 @@ set -eu
 raw_targets=$(sed -E -n -e 's/^.* - documentation_targets: \[(.*)\].*$/\1/p' .spi.yml)
 targets=(${raw_targets//,/ })
 
+# Add the DocC plugin.
+swift package add-dependency https://github.com/apple/swift-docc-plugin --from "1.0.0"
+
 for target in "${targets[@]}"; do
   swift package plugin generate-documentation --target "$target" --warnings-as-errors --analyze --level detailed
 done

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -18,8 +18,8 @@ set -eu
 raw_targets=$(sed -E -n -e 's/^.* - documentation_targets: \[(.*)\].*$/\1/p' .spi.yml)
 targets=(${raw_targets//,/ })
 
-# Add the DocC plugin.
-swift package add-dependency https://github.com/apple/swift-docc-plugin --from "1.0.0"
+# Add the DocC plugin; the doc checking CI runs on 5.8 so we can't use "swift package add-dependency".
+echo 'package.dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"))' >> Package.swift
 
 for target in "${targets[@]}"; do
   swift package plugin generate-documentation --target "$target" --warnings-as-errors --analyze --level detailed


### PR DESCRIPTION
Motivation:

Swift Package Index builds our docs for us and will automatically insert the dependency.

Modifications:

- Remove the docc-plugin dependency

Result:

Fewer dependencies