### PR TITLE
Don't depend on NIOFoundationCompat in NIOTransportServices on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,12 @@
 
 import PackageDescription
 
+#if compiler(>=5.9)
+let applePlatforms: [Platform] = [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit, .visionOS]
+#else
+let applePlatforms: [Platform] = [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit]
+#endif
+
 let package = Package(
     name: "swift-nio-transport-services",
     products: [
@@ -30,7 +36,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit])),
+                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: applePlatforms)),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ]),

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit]),
+                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit])),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ]),

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit]),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ]),


### PR DESCRIPTION
Don't depend on NIOFoundationCompat in NIOTransportServices on Linux

### Motivation:

I'm trying to build a small utility tool based on mqtt-nio which depends on NIOTransportServices. I noticed that NIOTransportServices depends on NIOFoundationCompat on all platforms but only imports it where the Network framework is available. Removing this dependency on non-Apple platforms allows us to not import Foundations, significantly reducing the size of the build product when using the Swift Static Linux SDK.

### Modifications:

This PR and a similar one to mqtt-nio.

### Result:

Hello world docker image depending on mqtt-nio went from 169MB to 85MB.
