### PR TITLE
Revert "Don't depend on NIOFoundationCompat in NIOTransportServices on Linux (#209)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,6 @@
 
 import PackageDescription
 
-#if compiler(>=5.9)
-let applePlatforms: [Platform] = [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit, .visionOS]
-#else
-let applePlatforms: [Platform] = [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit]
-#endif
-
 let package = Package(
     name: "swift-nio-transport-services",
     products: [
@@ -36,7 +30,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: applePlatforms)),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ]),


### PR DESCRIPTION
This reverts commit 40ffcdef465d0870113b531b08454fe1712c01de in PR #209.

Unfortunately, Swift's behaviour around imports tends to be somewhat "leaky". In this case, the leak is that the dependency on the Package.swift allows downstream projects to import `NIOFoundationCompat` without needing to actually specify the package dependency. This has affected Hummingbird, which we noticed on our internal integration testing functionality:

```
hummingbird/Sources/Hummingbird/Codable/JSON/JSONCoding.swift:18:8: error: no such module 'NIOFoundationCompat'
import NIOFoundationCompat
       ^
```

cc @Joannis @adam-fowler for the Hummingbird report.

Unfortunately, we can't make this change until we're willing to use a semver major to achieve it. There may be some argument for doing that now, as the semver major will be very cheap to adopt across the ecosystem. But we'll need to do this in a considered way.

@Cyberbeni please feel free to reopen your PR targetting main, where we can discuss whether this is worth issuing a semver major for.