### PR TITLE
Provide configurability for receiving connection data

### DIFF
--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
@@ -68,6 +68,12 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
     /// after the initial connection attempt has been made.
     internal var connection: NWConnection?
 
+    /// The minimum length of data to receive from this connection, until the content is complete.
+    internal var minimumIncompleteReceiveLength: Int
+
+    /// The maximum length of data to receive from this connection in a single completion.
+    internal var maximumReceiveLength: Int
+
     /// The `DispatchQueue` that socket events for this connection will be dispatched onto.
     internal let connectionQueue: DispatchQueue
 
@@ -169,11 +175,15 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
     internal init(eventLoop: NIOTSEventLoop,
                   parent: Channel? = nil,
                   qos: DispatchQoS? = nil,
+                  minimumIncompleteReceiveLength: Int = 1,
+                  maximumReceiveLength: Int = 8192,
                   udpOptions: NWProtocolUDP.Options,
                   tlsOptions: NWProtocolTLS.Options?) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
         self.parent = parent
+        self.minimumIncompleteReceiveLength = minimumIncompleteReceiveLength
+        self.maximumReceiveLength = maximumReceiveLength
         self.connectionQueue = eventLoop.channelQueue(label: "nio.nioTransportServices.connectionchannel", qos: qos)
         self.udpOptions = udpOptions
         self.tlsOptions = tlsOptions
@@ -187,11 +197,15 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
                               on eventLoop: NIOTSEventLoop,
                               parent: Channel,
                               qos: DispatchQoS? = nil,
+                              minimumIncompleteReceiveLength: Int = 1,
+                              maximumReceiveLength: Int = 8192,
                               udpOptions: NWProtocolUDP.Options,
                               tlsOptions: NWProtocolTLS.Options?) {
         self.init(eventLoop: eventLoop,
                   parent: parent,
                   qos: qos,
+                  minimumIncompleteReceiveLength: minimumIncompleteReceiveLength,
+                  maximumReceiveLength: maximumReceiveLength,
                   udpOptions: udpOptions,
                   tlsOptions: tlsOptions)
         self.connection = connection

--- a/Sources/NIOTransportServices/NIOTSChannelOptions.swift
+++ b/Sources/NIOTransportServices/NIOTSChannelOptions.swift
@@ -53,6 +53,12 @@ public struct NIOTSChannelOptions {
     /// See: ``Types/NIOTSListenerOption``.
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     public static let listener = NIOTSChannelOptions.Types.NIOTSListenerOption()
+
+    /// See: ``Types/NIOTSMinimumIncompleteReceiveLengthOption``.
+    public static let minimumIncompleteReceiveLength = NIOTSChannelOptions.Types.NIOTSMinimumIncompleteReceiveLengthOption()
+
+    /// See: ``Types/NIOTSMaximumReceiveLengthOption``.
+    public static let maximumReceiveLength = NIOTSChannelOptions.Types.NIOTSMaximumReceiveLengthOption()
 }
 
 
@@ -176,6 +182,26 @@ extension NIOTSChannelOptions {
         @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
         public struct NIOTSListenerOption: ChannelOption, Equatable {
             public typealias Value = NWListener?
+
+            public init() {}
+        }
+
+        /// ``NIOTSMinimumIncompleteReceiveLengthOption`` controls the minimum length to receive from a given
+        /// `NWConnection`, until the content is complete.
+        ///
+        /// This option is only valid with a `Channel` backed by an `NWConnection`.
+        public struct NIOTSMinimumIncompleteReceiveLengthOption: ChannelOption, Equatable {
+            public typealias Value = Int
+
+            public init() {}
+        }
+
+        /// ``NIOTSMaximumReceiveLengthOption`` controls the maximum length to receive from a given
+        /// `NWConnection` in a single completion.
+        ///
+        /// This option is only valid with a `Channel` backed by an `NWConnection`.
+        public struct NIOTSMaximumReceiveLengthOption: ChannelOption, Equatable {
+            public typealias Value = Int
 
             public init() {}
         }

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -150,6 +150,12 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
     /// after the initial connection attempt has been made.
     internal var connection: NWConnection?
 
+    /// The minimum length of data to receive from this connection, until the content is complete.
+    internal var minimumIncompleteReceiveLength: Int
+
+    /// The maximum length of data to receive from this connection in a single completion.
+    internal var maximumReceiveLength: Int
+
     /// The `DispatchQueue` that socket events for this connection will be dispatched onto.
     internal let connectionQueue: DispatchQueue
 
@@ -230,11 +236,15 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
     internal init(eventLoop: NIOTSEventLoop,
                   parent: Channel? = nil,
                   qos: DispatchQoS? = nil,
+                  minimumIncompleteReceiveLength: Int = 1,
+                  maximumReceiveLength: Int = 8192,
                   tcpOptions: NWProtocolTCP.Options,
                   tlsOptions: NWProtocolTLS.Options?) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
         self.parent = parent
+        self.minimumIncompleteReceiveLength = minimumIncompleteReceiveLength
+        self.maximumReceiveLength = maximumReceiveLength
         self.connectionQueue = eventLoop.channelQueue(label: "nio.nioTransportServices.connectionchannel", qos: qos)
         self.tcpOptions = tcpOptions
         self.tlsOptions = tlsOptions
@@ -248,11 +258,15 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
                               on eventLoop: NIOTSEventLoop,
                               parent: Channel? = nil,
                               qos: DispatchQoS? = nil,
+                              minimumIncompleteReceiveLength: Int = 1,
+                              maximumReceiveLength: Int = 8192,
                               tcpOptions: NWProtocolTCP.Options,
                               tlsOptions: NWProtocolTLS.Options?) {
         self.init(eventLoop: eventLoop,
                   parent: parent,
                   qos: qos,
+                  minimumIncompleteReceiveLength: minimumIncompleteReceiveLength,
+                  maximumReceiveLength: maximumReceiveLength,
                   tcpOptions: tcpOptions,
                   tlsOptions: tlsOptions)
         self.connection = connection

--- a/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelOptionsTests.swift
@@ -139,5 +139,45 @@ class NIOTSChannelOptionsTests: XCTestCase {
         XCTAssertEqual(listenerValue, .handover)
         XCTAssertEqual(connectionValue, .interactive)
     }
+
+    func testMinimumIncompleteReceiveLength() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connection = try NIOTSConnectionBootstrap(group: self.group)
+            .channelOption(NIOTSChannelOptions.minimumIncompleteReceiveLength, value: 1)
+            .connect(to: listener.localAddress!)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try connection.close().wait())
+        }
+
+        let connectionValue = try assertNoThrowWithValue(connection.getOption(NIOTSChannelOptions.minimumIncompleteReceiveLength).wait())
+
+        XCTAssertEqual(connectionValue, 1)
+    }
+
+    func testMaximumReceiveLength() throws {
+        let listener = try NIOTSListenerBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try listener.close().wait())
+        }
+
+        let connection = try NIOTSConnectionBootstrap(group: self.group)
+            .channelOption(NIOTSChannelOptions.maximumReceiveLength, value: 8192)
+            .connect(to: listener.localAddress!)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try connection.close().wait())
+        }
+
+        let connectionValue = try assertNoThrowWithValue(connection.getOption(NIOTSChannelOptions.maximumReceiveLength).wait())
+
+        XCTAssertEqual(connectionValue, 8192)
+    }
 }
 #endif


### PR DESCRIPTION
Motivation:

Users are stuck with the hardcoded parameters for receiving data from a connection.

Modifications:

- Add new options to `NIOTSChannelOptions` for configuring how to receive data from a connection.

Result:

Users can configure how they receive data from a connection.