### PR TITLE
Remove integration tests workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,3 @@ jobs:
             linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-
-    integration-tests:
-        name: Integration test
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
-        with:
-            name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq lsof dnsutils netcat-openbsd net-tools expect curl jq && ./scripts/integration_tests.sh"


### PR DESCRIPTION
Remove the integration tests workflow from the main and scheduled jobs.

### Motivation:

There are no integration tests in this repository.
(see https://github.com/apple/swift-nio-transport-services/actions/runs/11833082880)

### Modifications:

Remove the integration tests workflow from the main and scheduled jobs.

### Result:

No more scheduled run failures.
