### PR TITLE
Add missing Dispatch import

### DIFF
--- a/Sources/NIOTransportServices/NIOTSSingletons.swift
+++ b/Sources/NIOTransportServices/NIOTSSingletons.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Network)
+import Dispatch
 import NIOCore
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)

--- a/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Network)
+import Atomics
 import Foundation
 import NIOCore
 import NIOConcurrencyHelpers

--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -16,6 +16,7 @@
 import XCTest
 import Network
 import NIOCore
+import NIOFoundationCompat
 import NIOTransportServices
 import Foundation
 


### PR DESCRIPTION
Motivation:

Dispatch wasn't imported in `NIOTSSingletons.swift` where `.default` was used for the default QoS. This causes some build issues.

Modifications:

- Add missing Dispatch import

Result:

Fewer build issues