### PR TITLE
Enable macOS CI on merge to main and daily timer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,3 +16,9 @@ jobs:
             linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+
+    macos-tests:
+        name: macOS tests
+        uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+        with:
+            build_scheme: swift-nio-transport-services-Package


### PR DESCRIPTION
Enable macOS CI on merge to main and daily timer

### Motivation:

* Improve test coverage
* Check test pass/fail status
* Monitor CI throughput

### Modifications:

Enable macOS CI to be run on all merges to main and on a daily timer.

### Result:

Improved test coverage run out-of-band at the moment so we can get a feeling for if any changes need to be made in the repo or in the CI pipelines to ensure timely and stable checks.