### PR TITLE
Add `NWParameters` configurator to bootstraps

### DIFF
--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramBootstrap.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramBootstrap.swift
@@ -47,7 +47,7 @@ public final class NIOTSDatagramBootstrap {
     private var qos: DispatchQoS?
     private var udpOptions: NWProtocolUDP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
-    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    private var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// Create a `NIOTSDatagramConnectionBootstrap` on the `EventLoopGroup` `group`.
     ///
@@ -136,7 +136,7 @@ public final class NIOTSDatagramBootstrap {
 
     /// Customise the `NWParameters` to be used when creating the connection.
     public func configureNWParameters(
-        _ configurator: @Sendable @escaping (inout NWParameters) -> Void
+        _ configurator: @Sendable @escaping (NWParameters) -> Void
     ) -> Self {
         self.nwParametersConfigurator = configurator
         return self

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramBootstrap.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramBootstrap.swift
@@ -47,6 +47,7 @@ public final class NIOTSDatagramBootstrap {
     private var qos: DispatchQoS?
     private var udpOptions: NWProtocolUDP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
+    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
 
     /// Create a `NIOTSDatagramConnectionBootstrap` on the `EventLoopGroup` `group`.
     ///
@@ -133,6 +134,14 @@ public final class NIOTSDatagramBootstrap {
         return self
     }
 
+    /// Customise the `NWParameters` to be used when creating the connection.
+    public func configureNWParameters(
+        _ configurator: @Sendable @escaping (inout NWParameters) -> Void
+    ) -> Self {
+        self.nwParametersConfigurator = configurator
+        return self
+    }
+
     /// Specify the `host` and `port` to connect to for the UDP `Channel` that will be established.
     ///
     /// - parameters:
@@ -188,7 +197,8 @@ public final class NIOTSDatagramBootstrap {
             eventLoop: self.group.next() as! NIOTSEventLoop,
             qos: self.qos,
             udpOptions: self.udpOptions,
-            tlsOptions: self.tlsOptions
+            tlsOptions: self.tlsOptions,
+            nwParametersConfigurator: self.nwParametersConfigurator
         )
         let initializer = self.channelInitializer ?? { @Sendable _ in conn.eventLoop.makeSucceededFuture(()) }
 

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
@@ -140,7 +140,7 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
     internal var allowLocalEndpointReuse = false
     internal var multipathServiceType: NWParameters.MultipathServiceType = .disabled
 
-    private let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
+    internal let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     var parameters: NWParameters {
         let parameters = NWParameters(dtls: self.tlsOptions, udp: self.udpOptions)

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
@@ -140,8 +140,12 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
     internal var allowLocalEndpointReuse = false
     internal var multipathServiceType: NWParameters.MultipathServiceType = .disabled
 
+    private let nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+
     var parameters: NWParameters {
-        NWParameters(dtls: self.tlsOptions, udp: self.udpOptions)
+        var parameters = NWParameters(dtls: self.tlsOptions, udp: self.udpOptions)
+        self.nwParametersConfigurator?(&parameters)
+        return parameters
     }
 
     var _inboundStreamOpen: Bool {
@@ -182,7 +186,8 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
         minimumIncompleteReceiveLength: Int = 1,
         maximumReceiveLength: Int = 8192,
         udpOptions: NWProtocolUDP.Options,
-        tlsOptions: NWProtocolTLS.Options?
+        tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
@@ -192,6 +197,7 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
         self.connectionQueue = eventLoop.channelQueue(label: "nio.nioTransportServices.connectionchannel", qos: qos)
         self.udpOptions = udpOptions
         self.tlsOptions = tlsOptions
+        self.nwParametersConfigurator = nwParametersConfigurator
 
         // Must come last, as it requires self to be completely initialized.
         self._pipeline = ChannelPipeline(channel: self)
@@ -206,7 +212,8 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
         minimumIncompleteReceiveLength: Int = 1,
         maximumReceiveLength: Int = 8192,
         udpOptions: NWProtocolUDP.Options,
-        tlsOptions: NWProtocolTLS.Options?
+        tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,
@@ -215,7 +222,8 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
             minimumIncompleteReceiveLength: minimumIncompleteReceiveLength,
             maximumReceiveLength: maximumReceiveLength,
             udpOptions: udpOptions,
-            tlsOptions: tlsOptions
+            tlsOptions: tlsOptions,
+            nwParametersConfigurator: nwParametersConfigurator
         )
         self.connection = connection
     }

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramChannel.swift
@@ -140,11 +140,11 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
     internal var allowLocalEndpointReuse = false
     internal var multipathServiceType: NWParameters.MultipathServiceType = .disabled
 
-    private let nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    private let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     var parameters: NWParameters {
-        var parameters = NWParameters(dtls: self.tlsOptions, udp: self.udpOptions)
-        self.nwParametersConfigurator?(&parameters)
+        let parameters = NWParameters(dtls: self.tlsOptions, udp: self.udpOptions)
+        self.nwParametersConfigurator?(parameters)
         return parameters
     }
 
@@ -187,7 +187,7 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
         maximumReceiveLength: Int = 8192,
         udpOptions: NWProtocolUDP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
@@ -213,7 +213,7 @@ internal final class NIOTSDatagramChannel: StateManagedNWConnectionChannel {
         maximumReceiveLength: Int = 8192,
         udpOptions: NWProtocolUDP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramListener.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramListener.swift
@@ -64,9 +64,12 @@ public final class NIOTSDatagramListenerBootstrap {
     private var serverQoS: DispatchQoS?
     private var childQoS: DispatchQoS?
     private var udpOptions: NWProtocolUDP.Options = .init()
+    private var childUDPOptions: NWProtocolUDP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
+    private var childTLSOptions: NWProtocolTLS.Options?
     private var bindTimeout: TimeAmount?
     private var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
+    private var childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// Create a ``NIOTSListenerBootstrap`` for the `EventLoopGroup` `group`.
     ///
@@ -225,23 +228,43 @@ public final class NIOTSDatagramListenerBootstrap {
         return self
     }
 
-    /// Specifies the TCP options to use on the child `Channel`s.
+    /// Specifies the TCP options to use on the listener.
     public func udpOptions(_ options: NWProtocolUDP.Options) -> Self {
         self.udpOptions = options
         return self
     }
 
-    /// Specifies the TLS options to use on the child `Channel`s.
+    /// Specifies the TCP options to use on the child `Channel`s.
+    public func childUDPOptions(_ options: NWProtocolUDP.Options) -> Self {
+        self.childUDPOptions = options
+        return self
+    }
+
+    /// Specifies the TLS options to use on the listener.
     public func tlsOptions(_ options: NWProtocolTLS.Options) -> Self {
         self.tlsOptions = options
         return self
     }
 
-    /// Customise the `NWParameters` to be used when creating the connection.
+    /// Specifies the TLS options to use on the child `Channel`s.
+    public func childTLSOptions(_ options: NWProtocolTLS.Options) -> Self {
+        self.childTLSOptions = options
+        return self
+    }
+
+    /// Customise the `NWParameters` to be used when creating the `NWConnection` for the listener.
     public func configureNWParameters(
         _ configurator: @Sendable @escaping (NWParameters) -> Void
     ) -> Self {
         self.nwParametersConfigurator = configurator
+        return self
+    }
+
+    /// Customise the `NWParameters` to be used when creating the `NWConnection`s for the child `Channel`s.
+    public func configureChildNWParameters(
+        _ configurator: @Sendable @escaping (NWParameters) -> Void
+    ) -> Self {
+        self.childNWParametersConfigurator = configurator
         return self
     }
 
@@ -339,9 +362,9 @@ public final class NIOTSDatagramListenerBootstrap {
                 nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
-                childUDPOptions: self.udpOptions,
-                childTLSOptions: self.tlsOptions,
-                childNWParametersConfigurator: self.nwParametersConfigurator
+                childUDPOptions: self.childUDPOptions,
+                childTLSOptions: self.childTLSOptions,
+                childNWParametersConfigurator: self.childNWParametersConfigurator
             )
         } else {
             serverChannel = NIOTSDatagramListenerChannel(
@@ -352,9 +375,9 @@ public final class NIOTSDatagramListenerBootstrap {
                 nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
-                childUDPOptions: self.udpOptions,
-                childTLSOptions: self.tlsOptions,
-                childNWParametersConfigurator: self.nwParametersConfigurator
+                childUDPOptions: self.childUDPOptions,
+                childTLSOptions: self.childTLSOptions,
+                childNWParametersConfigurator: self.childNWParametersConfigurator
             )
         }
 

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramListener.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramListener.swift
@@ -66,6 +66,7 @@ public final class NIOTSDatagramListenerBootstrap {
     private var udpOptions: NWProtocolUDP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
     private var bindTimeout: TimeAmount?
+    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
 
     /// Create a ``NIOTSListenerBootstrap`` for the `EventLoopGroup` `group`.
     ///
@@ -236,6 +237,14 @@ public final class NIOTSDatagramListenerBootstrap {
         return self
     }
 
+    /// Customise the `NWParameters` to be used when creating the connection.
+    public func configureNWParameters(
+        _ configurator: @Sendable @escaping (inout NWParameters) -> Void
+    ) -> Self {
+        self.nwParametersConfigurator = configurator
+        return self
+    }
+
     /// Bind the `NIOTSListenerChannel` to `host` and `port`.
     ///
     /// - parameters:
@@ -327,10 +336,12 @@ public final class NIOTSDatagramListenerBootstrap {
                 qos: self.serverQoS,
                 udpOptions: self.udpOptions,
                 tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
                 childUDPOptions: self.udpOptions,
-                childTLSOptions: self.tlsOptions
+                childTLSOptions: self.tlsOptions,
+                childNWParametersConfigurator: self.nwParametersConfigurator
             )
         } else {
             serverChannel = NIOTSDatagramListenerChannel(
@@ -338,10 +349,12 @@ public final class NIOTSDatagramListenerBootstrap {
                 qos: self.serverQoS,
                 udpOptions: self.udpOptions,
                 tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
                 childUDPOptions: self.udpOptions,
-                childTLSOptions: self.tlsOptions
+                childTLSOptions: self.tlsOptions,
+                childNWParametersConfigurator: self.nwParametersConfigurator
             )
         }
 

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramListener.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramListener.swift
@@ -66,7 +66,7 @@ public final class NIOTSDatagramListenerBootstrap {
     private var udpOptions: NWProtocolUDP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
     private var bindTimeout: TimeAmount?
-    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    private var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// Create a ``NIOTSListenerBootstrap`` for the `EventLoopGroup` `group`.
     ///
@@ -239,7 +239,7 @@ public final class NIOTSDatagramListenerBootstrap {
 
     /// Customise the `NWParameters` to be used when creating the connection.
     public func configureNWParameters(
-        _ configurator: @Sendable @escaping (inout NWParameters) -> Void
+        _ configurator: @Sendable @escaping (NWParameters) -> Void
     ) -> Self {
         self.nwParametersConfigurator = configurator
         return self

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramListenerChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramListenerChannel.swift
@@ -81,12 +81,12 @@ internal final class NIOTSDatagramListenerChannel: StateManagedListenerChannel<N
         qos: DispatchQoS? = nil,
         udpOptions: NWProtocolUDP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childUDPOptions: NWProtocolUDP.Options,
         childTLSOptions: NWProtocolTLS.Options?,
-        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,
@@ -108,12 +108,12 @@ internal final class NIOTSDatagramListenerChannel: StateManagedListenerChannel<N
         qos: DispatchQoS? = nil,
         udpOptions: NWProtocolUDP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childUDPOptions: NWProtocolUDP.Options,
         childTLSOptions: NWProtocolTLS.Options?,
-        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             wrapping: listener,

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramListenerChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramListenerChannel.swift
@@ -81,19 +81,23 @@ internal final class NIOTSDatagramListenerChannel: StateManagedListenerChannel<N
         qos: DispatchQoS? = nil,
         udpOptions: NWProtocolUDP.Options,
         tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childUDPOptions: NWProtocolUDP.Options,
-        childTLSOptions: NWProtocolTLS.Options?
+        childTLSOptions: NWProtocolTLS.Options?,
+        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,
             protocolOptions: .udp(udpOptions),
             tlsOptions: tlsOptions,
+            nwParametersConfigurator: nwParametersConfigurator,
             childLoopGroup: childLoopGroup,
             childChannelQoS: childChannelQoS,
             childProtocolOptions: .udp(childUDPOptions),
-            childTLSOptions: childTLSOptions
+            childTLSOptions: childTLSOptions,
+            childNWParametersConfigurator: childNWParametersConfigurator
         )
     }
 
@@ -104,20 +108,24 @@ internal final class NIOTSDatagramListenerChannel: StateManagedListenerChannel<N
         qos: DispatchQoS? = nil,
         udpOptions: NWProtocolUDP.Options,
         tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childUDPOptions: NWProtocolUDP.Options,
-        childTLSOptions: NWProtocolTLS.Options?
+        childTLSOptions: NWProtocolTLS.Options?,
+        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.init(
             wrapping: listener,
             eventLoop: eventLoop,
             protocolOptions: .udp(udpOptions),
             tlsOptions: tlsOptions,
+            nwParametersConfigurator: nwParametersConfigurator,
             childLoopGroup: childLoopGroup,
             childChannelQoS: childChannelQoS,
             childProtocolOptions: .udp(childUDPOptions),
-            childTLSOptions: childTLSOptions
+            childTLSOptions: childTLSOptions,
+            childNWParametersConfigurator: childNWParametersConfigurator
         )
     }
 
@@ -132,7 +140,8 @@ internal final class NIOTSDatagramListenerChannel: StateManagedListenerChannel<N
             on: self.childLoopGroup.next() as! NIOTSEventLoop,
             parent: self,
             udpOptions: self.childUDPOptions,
-            tlsOptions: self.childTLSOptions
+            tlsOptions: self.childTLSOptions,
+            nwParametersConfigurator: self.childNWParametersConfigurator
         )
 
         self.pipeline.fireChannelRead(newChannel)

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -62,6 +62,7 @@ public final class NIOTSConnectionBootstrap {
     private var tcpOptions: NWProtocolTCP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
     private var protocolHandlers: (@Sendable () -> [ChannelHandler])? = nil
+    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
 
     /// Create a `NIOTSConnectionBootstrap` on the `EventLoopGroup` `group`.
     ///
@@ -165,6 +166,14 @@ public final class NIOTSConnectionBootstrap {
         self.channelOption(NIOTSChannelOptions.multipathServiceType, value: type)
     }
 
+    /// Customise the `NWParameters` to be used when creating the connection.
+    public func configureNWParameters(
+        _ configurator: @Sendable @escaping (inout NWParameters) -> Void
+    ) -> Self {
+        self.nwParametersConfigurator = configurator
+        return self
+    }
+
     /// Specify the `host` and `port` to connect to for the TCP `Channel` that will be established.
     ///
     /// - parameters:
@@ -243,14 +252,16 @@ public final class NIOTSConnectionBootstrap {
                 wrapping: newConnection,
                 on: self.group.next() as! NIOTSEventLoop,
                 tcpOptions: self.tcpOptions,
-                tlsOptions: self.tlsOptions
+                tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator
             )
         } else {
             conn = NIOTSConnectionChannel(
                 eventLoop: self.group.next() as! NIOTSEventLoop,
                 qos: self.qos,
                 tcpOptions: self.tcpOptions,
-                tlsOptions: self.tlsOptions
+                tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator
             )
         }
         let initializer = self.channelInitializer
@@ -437,14 +448,16 @@ extension NIOTSConnectionBootstrap {
                 wrapping: newConnection,
                 on: self.group.next() as! NIOTSEventLoop,
                 tcpOptions: self.tcpOptions,
-                tlsOptions: self.tlsOptions
+                tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator
             )
         } else {
             connectionChannel = NIOTSConnectionChannel(
                 eventLoop: self.group.next() as! NIOTSEventLoop,
                 qos: self.qos,
                 tcpOptions: self.tcpOptions,
-                tlsOptions: self.tlsOptions
+                tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator
             )
         }
         let initializer = self.channelInitializer

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -62,7 +62,7 @@ public final class NIOTSConnectionBootstrap {
     private var tcpOptions: NWProtocolTCP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
     private var protocolHandlers: (@Sendable () -> [ChannelHandler])? = nil
-    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    private var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// Create a `NIOTSConnectionBootstrap` on the `EventLoopGroup` `group`.
     ///
@@ -168,7 +168,7 @@ public final class NIOTSConnectionBootstrap {
 
     /// Customise the `NWParameters` to be used when creating the connection.
     public func configureNWParameters(
-        _ configurator: @Sendable @escaping (inout NWParameters) -> Void
+        _ configurator: @Sendable @escaping (NWParameters) -> Void
     ) -> Self {
         self.nwParametersConfigurator = configurator
         return self

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -164,11 +164,11 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
     /// An `EventLoopPromise` that will be succeeded or failed when a connection attempt succeeds or fails.
     internal var connectPromise: EventLoopPromise<Void>?
 
-    private let nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    private let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     internal var parameters: NWParameters {
-        var parameters = NWParameters(tls: self.tlsOptions, tcp: self.tcpOptions)
-        self.nwParametersConfigurator?(&parameters)
+        let parameters = NWParameters(tls: self.tlsOptions, tcp: self.tcpOptions)
+        self.nwParametersConfigurator?(parameters)
         return parameters
     }
 
@@ -247,7 +247,7 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
         maximumReceiveLength: Int = 8192,
         tcpOptions: NWProtocolTCP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
@@ -273,7 +273,7 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
         maximumReceiveLength: Int = 8192,
         tcpOptions: NWProtocolTCP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -164,7 +164,7 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
     /// An `EventLoopPromise` that will be succeeded or failed when a connection attempt succeeds or fails.
     internal var connectPromise: EventLoopPromise<Void>?
 
-    private let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
+    internal let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     internal var parameters: NWParameters {
         let parameters = NWParameters(tls: self.tlsOptions, tcp: self.tcpOptions)

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -64,9 +64,12 @@ public final class NIOTSListenerBootstrap {
     private var serverQoS: DispatchQoS?
     private var childQoS: DispatchQoS?
     private var tcpOptions: NWProtocolTCP.Options = .init()
+    private var childTCPOptions: NWProtocolTCP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
+    private var childTLSOptions: NWProtocolTLS.Options?
     private var bindTimeout: TimeAmount?
     private var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
+    private var childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// Create a ``NIOTSListenerBootstrap`` for the `EventLoopGroup` `group`.
     ///
@@ -228,23 +231,43 @@ public final class NIOTSListenerBootstrap {
         return self
     }
 
-    /// Specifies the TCP options to use on the child `Channel`s.
+    /// Specifies the TCP options to use on the listener.
     public func tcpOptions(_ options: NWProtocolTCP.Options) -> Self {
         self.tcpOptions = options
         return self
     }
 
-    /// Specifies the TLS options to use on the child `Channel`s.
+    /// Specifies the TCP options to use on the child `Channel`s.
+    public func childTCPOptions(_ options: NWProtocolTCP.Options) -> Self {
+        self.childTCPOptions = options
+        return self
+    }
+
+    /// Specifies the TLS options to use on the listener.
     public func tlsOptions(_ options: NWProtocolTLS.Options) -> Self {
         self.tlsOptions = options
         return self
     }
 
-    /// Customise the `NWParameters` to be used when creating the connection.
+    /// Specifies the TLS options to use on the child `Channel`s.
+    public func childTLSOptions(_ options: NWProtocolTLS.Options) -> Self {
+        self.childTLSOptions = options
+        return self
+    }
+
+    /// Customise the `NWParameters` to be used when creating the `NWConnection` for the listener.
     public func configureNWParameters(
         _ configurator: @Sendable @escaping (NWParameters) -> Void
     ) -> Self {
         self.nwParametersConfigurator = configurator
+        return self
+    }
+
+    /// Customise the `NWParameters` to be used when creating the `NWConnection`s for the child `Channel`s.
+    public func configureChildNWParameters(
+        _ configurator: @Sendable @escaping (NWParameters) -> Void
+    ) -> Self {
+        self.childNWParametersConfigurator = configurator
         return self
     }
 
@@ -349,9 +372,9 @@ public final class NIOTSListenerBootstrap {
                 nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
-                childTCPOptions: self.tcpOptions,
-                childTLSOptions: self.tlsOptions,
-                childNWParametersConfigurator: self.nwParametersConfigurator
+                childTCPOptions: self.childTCPOptions,
+                childTLSOptions: self.childTLSOptions,
+                childNWParametersConfigurator: self.childNWParametersConfigurator
             )
         } else {
             serverChannel = NIOTSListenerChannel(
@@ -362,9 +385,9 @@ public final class NIOTSListenerBootstrap {
                 nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
-                childTCPOptions: self.tcpOptions,
-                childTLSOptions: self.tlsOptions,
-                childNWParametersConfigurator: self.nwParametersConfigurator
+                childTCPOptions: self.childTCPOptions,
+                childTLSOptions: self.childTLSOptions,
+                childNWParametersConfigurator: self.childNWParametersConfigurator
             )
         }
 

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -240,6 +240,14 @@ public final class NIOTSListenerBootstrap {
         return self
     }
 
+    /// Customise the `NWParameters` to be used when creating the connection.
+    public func configureNWParameters(
+        _ configurator: @Sendable @escaping (NWParameters) -> Void
+    ) -> Self {
+        self.nwParametersConfigurator = configurator
+        return self
+    }
+
     /// Specifies a type of Multipath service to use for this listener, instead of the default
     /// service type for the event loop.
     ///

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -66,7 +66,7 @@ public final class NIOTSListenerBootstrap {
     private var tcpOptions: NWProtocolTCP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
     private var bindTimeout: TimeAmount?
-    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    private var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// Create a ``NIOTSListenerBootstrap`` for the `EventLoopGroup` `group`.
     ///

--- a/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerBootstrap.swift
@@ -66,6 +66,7 @@ public final class NIOTSListenerBootstrap {
     private var tcpOptions: NWProtocolTCP.Options = .init()
     private var tlsOptions: NWProtocolTLS.Options?
     private var bindTimeout: TimeAmount?
+    private var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
 
     /// Create a ``NIOTSListenerBootstrap`` for the `EventLoopGroup` `group`.
     ///
@@ -337,10 +338,12 @@ public final class NIOTSListenerBootstrap {
                 qos: self.serverQoS,
                 tcpOptions: self.tcpOptions,
                 tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
                 childTCPOptions: self.tcpOptions,
-                childTLSOptions: self.tlsOptions
+                childTLSOptions: self.tlsOptions,
+                childNWParametersConfigurator: self.nwParametersConfigurator
             )
         } else {
             serverChannel = NIOTSListenerChannel(
@@ -348,10 +351,12 @@ public final class NIOTSListenerBootstrap {
                 qos: self.serverQoS,
                 tcpOptions: self.tcpOptions,
                 tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
                 childTCPOptions: self.tcpOptions,
-                childTLSOptions: self.tlsOptions
+                childTLSOptions: self.tlsOptions,
+                childNWParametersConfigurator: self.nwParametersConfigurator
             )
         }
 
@@ -558,10 +563,12 @@ extension NIOTSListenerBootstrap {
                 qos: self.serverQoS,
                 tcpOptions: self.tcpOptions,
                 tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
                 childTCPOptions: self.tcpOptions,
-                childTLSOptions: self.tlsOptions
+                childTLSOptions: self.tlsOptions,
+                childNWParametersConfigurator: self.nwParametersConfigurator
             )
         } else {
             serverChannel = NIOTSListenerChannel(
@@ -569,10 +576,12 @@ extension NIOTSListenerBootstrap {
                 qos: self.serverQoS,
                 tcpOptions: self.tcpOptions,
                 tlsOptions: self.tlsOptions,
+                nwParametersConfigurator: self.nwParametersConfigurator,
                 childLoopGroup: self.childGroup,
                 childChannelQoS: self.childQoS,
                 childTCPOptions: self.tcpOptions,
-                childTLSOptions: self.tlsOptions
+                childTLSOptions: self.tlsOptions,
+                childNWParametersConfigurator: self.nwParametersConfigurator
             )
         }
 

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -81,12 +81,12 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
         qos: DispatchQoS? = nil,
         tcpOptions: NWProtocolTCP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childTCPOptions: NWProtocolTCP.Options,
         childTLSOptions: NWProtocolTLS.Options?,
-        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,
@@ -108,12 +108,12 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
         qos: DispatchQoS? = nil,
         tcpOptions: NWProtocolTCP.Options,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childTCPOptions: NWProtocolTCP.Options,
         childTLSOptions: NWProtocolTLS.Options?,
-        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             wrapping: listener,

--- a/Sources/NIOTransportServices/NIOTSListenerChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSListenerChannel.swift
@@ -81,19 +81,23 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
         qos: DispatchQoS? = nil,
         tcpOptions: NWProtocolTCP.Options,
         tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childTCPOptions: NWProtocolTCP.Options,
-        childTLSOptions: NWProtocolTLS.Options?
+        childTLSOptions: NWProtocolTLS.Options?,
+        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,
             protocolOptions: .tcp(tcpOptions),
             tlsOptions: tlsOptions,
+            nwParametersConfigurator: nwParametersConfigurator,
             childLoopGroup: childLoopGroup,
             childChannelQoS: childChannelQoS,
             childProtocolOptions: .tcp(childTCPOptions),
-            childTLSOptions: childTLSOptions
+            childTLSOptions: childTLSOptions,
+            childNWParametersConfigurator: childNWParametersConfigurator
         )
     }
 
@@ -104,10 +108,12 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
         qos: DispatchQoS? = nil,
         tcpOptions: NWProtocolTCP.Options,
         tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childTCPOptions: NWProtocolTCP.Options,
-        childTLSOptions: NWProtocolTLS.Options?
+        childTLSOptions: NWProtocolTLS.Options?,
+        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.init(
             wrapping: listener,
@@ -115,10 +121,12 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
             qos: qos,
             protocolOptions: .tcp(tcpOptions),
             tlsOptions: tlsOptions,
+            nwParametersConfigurator: nwParametersConfigurator,
             childLoopGroup: childLoopGroup,
             childChannelQoS: childChannelQoS,
             childProtocolOptions: .tcp(childTCPOptions),
-            childTLSOptions: childTLSOptions
+            childTLSOptions: childTLSOptions,
+            childNWParametersConfigurator: childNWParametersConfigurator
         )
     }
 
@@ -134,7 +142,8 @@ internal final class NIOTSListenerChannel: StateManagedListenerChannel<NIOTSConn
             parent: self,
             qos: self.childChannelQoS,
             tcpOptions: self.childTCPOptions,
-            tlsOptions: self.childTLSOptions
+            tlsOptions: self.childTLSOptions,
+            nwParametersConfigurator: self.childNWParametersConfigurator
         )
 
         self.pipeline.fireChannelRead(newChannel)

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -67,7 +67,7 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     /// The TLS options for this listener.
     internal let tlsOptions: NWProtocolTLS.Options?
 
-    internal var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    internal var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// The `DispatchQueue` that socket events for this connection will be dispatched onto.
     internal let connectionQueue: DispatchQueue
@@ -115,7 +115,7 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     /// The TLS options to use for child channels.
     internal let childTLSOptions: NWProtocolTLS.Options?
 
-    internal var childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+    internal var childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// The cache of the local and remote socket addresses. Must be accessed using _addressCacheLock.
     internal var addressCache = AddressCache(local: nil, remote: nil)
@@ -134,12 +134,12 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
         qos: DispatchQoS? = nil,
         protocolOptions: ProtocolOptions,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childProtocolOptions: ProtocolOptions,
         childTLSOptions: NWProtocolTLS.Options?,
-        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
@@ -161,12 +161,12 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
         qos: DispatchQoS? = nil,
         protocolOptions: ProtocolOptions,
         tlsOptions: NWProtocolTLS.Options?,
-        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
+        nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childProtocolOptions: ProtocolOptions,
         childTLSOptions: NWProtocolTLS.Options?,
-        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+        childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -410,6 +410,8 @@ extension StateManagedListenerChannel {
 
         parameters.multipathServiceType = self.multipathServiceType
 
+        self.nwParametersConfigurator?(parameters)
+
         let listener: NWListener
         do {
             listener = try NWListener(using: parameters)

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -67,7 +67,8 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     /// The TLS options for this listener.
     internal let tlsOptions: NWProtocolTLS.Options?
 
-    internal var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
+    /// A customization point for this listener's `NWParameters`.
+    internal let nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// The `DispatchQueue` that socket events for this connection will be dispatched onto.
     internal let connectionQueue: DispatchQueue
@@ -115,7 +116,8 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     /// The TLS options to use for child channels.
     internal let childTLSOptions: NWProtocolTLS.Options?
 
-    internal var childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
+    /// A customization point for each child's `NWParameters`.
+    internal let childNWParametersConfigurator: (@Sendable (NWParameters) -> Void)?
 
     /// The cache of the local and remote socket addresses. Must be accessed using _addressCacheLock.
     internal var addressCache = AddressCache(local: nil, remote: nil)

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -146,10 +146,12 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
         self.connectionQueue = eventLoop.channelQueue(label: "nio.transportservices.listenerchannel", qos: qos)
         self.protocolOptions = protocolOptions
         self.tlsOptions = tlsOptions
+        self.nwParametersConfigurator = nwParametersConfigurator
         self.childLoopGroup = childLoopGroup
         self.childChannelQoS = childChannelQoS
         self.childProtocolOptions = childProtocolOptions
         self.childTLSOptions = childTLSOptions
+        self.childNWParametersConfigurator = childNWParametersConfigurator
 
         // Must come last, as it requires self to be completely initialized.
         self._pipeline = ChannelPipeline(channel: self)

--- a/Sources/NIOTransportServices/StateManagedListenerChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedListenerChannel.swift
@@ -67,6 +67,8 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     /// The TLS options for this listener.
     internal let tlsOptions: NWProtocolTLS.Options?
 
+    internal var nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+
     /// The `DispatchQueue` that socket events for this connection will be dispatched onto.
     internal let connectionQueue: DispatchQueue
 
@@ -113,6 +115,8 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
     /// The TLS options to use for child channels.
     internal let childTLSOptions: NWProtocolTLS.Options?
 
+    internal var childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
+
     /// The cache of the local and remote socket addresses. Must be accessed using _addressCacheLock.
     internal var addressCache = AddressCache(local: nil, remote: nil)
 
@@ -130,10 +134,12 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
         qos: DispatchQoS? = nil,
         protocolOptions: ProtocolOptions,
         tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childProtocolOptions: ProtocolOptions,
-        childTLSOptions: NWProtocolTLS.Options?
+        childTLSOptions: NWProtocolTLS.Options?,
+        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.tsEventLoop = eventLoop
         self.closePromise = eventLoop.makePromise()
@@ -155,20 +161,24 @@ internal class StateManagedListenerChannel<ChildChannel: StateManagedChannel>: S
         qos: DispatchQoS? = nil,
         protocolOptions: ProtocolOptions,
         tlsOptions: NWProtocolTLS.Options?,
+        nwParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?,
         childLoopGroup: EventLoopGroup,
         childChannelQoS: DispatchQoS?,
         childProtocolOptions: ProtocolOptions,
-        childTLSOptions: NWProtocolTLS.Options?
+        childTLSOptions: NWProtocolTLS.Options?,
+        childNWParametersConfigurator: (@Sendable (inout NWParameters) -> Void)?
     ) {
         self.init(
             eventLoop: eventLoop,
             qos: qos,
             protocolOptions: protocolOptions,
             tlsOptions: tlsOptions,
+            nwParametersConfigurator: nwParametersConfigurator,
             childLoopGroup: childLoopGroup,
             childChannelQoS: childChannelQoS,
             childProtocolOptions: childProtocolOptions,
-            childTLSOptions: childTLSOptions
+            childTLSOptions: childTLSOptions,
+            childNWParametersConfigurator: childNWParametersConfigurator
         )
         self.nwListener = listener
     }

--- a/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
@@ -83,6 +83,8 @@ internal protocol StateManagedNWConnectionChannel: StateManagedChannel where Act
 
     var multipathServiceType: NWParameters.MultipathServiceType { get }
 
+    var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)? { get }
+
     func setChannelSpecificOption0<Option: ChannelOption>(option: Option, value: Option.Value) throws
 
     func getChannelSpecificOption0<Option: ChannelOption>(option: Option) throws -> Option.Value
@@ -242,6 +244,7 @@ extension StateManagedNWConnectionChannel {
         connection.betterPathUpdateHandler = self.betterPathHandler
         connection.viabilityUpdateHandler = self.viabilityUpdateHandler
         connection.pathUpdateHandler = self.pathChangedHandler(newPath:)
+        self.nwParametersConfigurator?(connection.parameters)
         connection.start(queue: self.connectionQueue)
     }
 

--- a/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSBootstrapTests.swift
@@ -372,22 +372,45 @@ final class NIOTSBootstrapTests: XCTestCase {
         XCTAssertEqual(try connectionChannel.getOption(NIOTSChannelOptions.multipathServiceType).wait(), .handover)
     }
 
-    func testNWParametersConfigurator() async throws {
-        final class WaitForConnectionHandler: ChannelInboundHandler, Sendable {
-            typealias InboundIn = Never
+    func testNWParametersConfigurator_ListenerUsesChildConfigurator() async throws {
+        try await withEventLoopGroup { group in
+            let configuratorListenerCounter = NIOLockedValueBox(0)
+            let configuratorConnectionCounter = NIOLockedValueBox(0)
+            let waitForConnectionHandler = WaitForConnectionHandler(
+                connectionPromise: group.next().makePromise()
+            )
 
-            let connectionPromise: EventLoopPromise<Void>
+            let listenerChannel = try await NIOTSListenerBootstrap(group: group)
+                .childChannelInitializer { connectionChannel in
+                    connectionChannel.eventLoop.makeCompletedFuture {
+                        try connectionChannel.pipeline.syncOperations.addHandler(waitForConnectionHandler)
+                    }
+                }
+                .configureNWParameters { _ in
+                    configuratorListenerCounter.withLockedValue { $0 += 1 }
+                }
+                .configureChildNWParameters { _ in
+                    configuratorConnectionCounter.withLockedValue { $0 += 1 }
+                }
+                .bind(host: "localhost", port: 0)
+                .get()
 
-            init(connectionPromise: EventLoopPromise<Void>) {
-                self.connectionPromise = connectionPromise
-            }
+            let connectionChannel: Channel = try await NIOTSConnectionBootstrap(group: group)
+                .connect(to: listenerChannel.localAddress!)
+                .get()
 
-            func channelActive(context: ChannelHandlerContext) {
-                self.connectionPromise.succeed()
-                context.fireChannelActive()
-            }
+            // Wait for the server to activate the connection channel to the client.
+            try await waitForConnectionHandler.connectionPromise.futureResult.get()
+
+            try await listenerChannel.close().get()
+            try await connectionChannel.close().get()
+
+            XCTAssertEqual(1, configuratorListenerCounter.withLockedValue { $0 })
+            XCTAssertEqual(1, configuratorConnectionCounter.withLockedValue { $0 })
         }
+    }
 
+    func testNWParametersConfigurator_ClientUsesConfigurator() async throws {
         try await withEventLoopGroup { group in
             let configuratorListenerCounter = NIOLockedValueBox(0)
             let configuratorConnectionCounter = NIOLockedValueBox(0)
@@ -414,13 +437,18 @@ final class NIOTSBootstrapTests: XCTestCase {
                 .connect(to: listenerChannel.localAddress!)
                 .get()
 
+            // Need to write something so the server can activate the connection channel: this is UDP,
+            // so there is no handshaking that happens and thus the server cannot know that the
+            // connection has been established and the channel can be activated until we receive something.
+            try await connectionChannel.writeAndFlush(ByteBuffer(bytes: [42]))
+
             // Wait for the server to activate the connection channel to the client.
             try await waitForConnectionHandler.connectionPromise.futureResult.get()
 
             try await listenerChannel.close().get()
             try await connectionChannel.close().get()
 
-            XCTAssertEqual(2, configuratorListenerCounter.withLockedValue { $0 })
+            XCTAssertEqual(1, configuratorListenerCounter.withLockedValue { $0 })
             XCTAssertEqual(1, configuratorConnectionCounter.withLockedValue { $0 })
         }
     }

--- a/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSChannelMetadataTests.swift
@@ -37,13 +37,14 @@ final class NIOTSChannelMetadataTests: XCTestCase {
         }.wait()
 
     }
-    func testThowsIfCalledOnANonInitializedChannel() {
+    func testThrowsIfCalledOnANonInitializedChannel() {
         let eventLoopGroup = NIOTSEventLoopGroup()
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let channel = NIOTSConnectionChannel(
             eventLoop: eventLoopGroup.next() as! NIOTSEventLoop,
             tcpOptions: .init(),
-            tlsOptions: .init()
+            tlsOptions: .init(),
+            nwParametersConfigurator: nil
         )
         XCTAssertThrowsError(try channel.getMetadata(definition: NWProtocolTLS.definition).wait()) { error in
             XCTAssertTrue(error is NIOTSConnectionNotInitialized, "unexpected error \(error)")

--- a/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSConnectionChannelTests.swift
@@ -272,11 +272,15 @@ class NIOTSConnectionChannelTests: XCTestCase {
     }
 
     func testSettingTCPOptionsWholesale() throws {
-        let tcpOptions = NWProtocolTCP.Options()
-        tcpOptions.disableAckStretching = true
+        let listenerTCPOptions = NWProtocolTCP.Options()
+        listenerTCPOptions.disableAckStretching = true
+
+        let connectionTCPOptions = NWProtocolTCP.Options()
+        connectionTCPOptions.disableAckStretching = true
 
         let listener = try NIOTSListenerBootstrap(group: self.group)
-            .tcpOptions(tcpOptions)
+            .tcpOptions(listenerTCPOptions)
+            .childTCPOptions(connectionTCPOptions)
             .serverChannelInitializer { channel in
                 channel.getOption(ChannelOptions.socket(IPPROTO_TCP, TCP_SENDMOREACKS)).map { value in
                     XCTAssertEqual(value, 1)
@@ -293,7 +297,7 @@ class NIOTSConnectionChannelTests: XCTestCase {
         }
 
         let connection = try NIOTSConnectionBootstrap(group: self.group)
-            .tcpOptions(tcpOptions)
+            .tcpOptions(connectionTCPOptions)
             .channelInitializer { channel in
                 channel.getOption(ChannelOptions.socket(IPPROTO_TCP, TCP_SENDMOREACKS)).map { value in
                     XCTAssertEqual(value, 1)

--- a/Tests/NIOTransportServicesTests/NIOTSDatagramConnectionChannelTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSDatagramConnectionChannelTests.swift
@@ -245,51 +245,50 @@ final class NIOTSDatagramConnectionChannelTests: XCTestCase {
 
             func channelActive(context: ChannelHandlerContext) {
                 self.connectionPromise.succeed()
+                context.fireChannelActive()
             }
         }
 
-        let group = NIOTSEventLoopGroup(loopCount: 1)
+        try await withEventLoopGroup { group in
+            let configuratorListenerCounter = NIOLockedValueBox(0)
+            let configuratorConnectionCounter = NIOLockedValueBox(0)
+            let waitForConnectionHandler = WaitForConnectionHandler(
+                connectionPromise: group.next().makePromise()
+            )
 
-        let configuratorListenerCounter = NIOLockedValueBox(0)
-        let configuratorConnectionCounter = NIOLockedValueBox(0)
-        let waitForConnectionHandler = WaitForConnectionHandler(
-            connectionPromise: group.next().makePromise()
-        )
-
-        let listenerChannel = try await NIOTSDatagramListenerBootstrap(group: group)
-            .childChannelInitializer { connectionChannel in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(waitForConnectionHandler)
+            let listenerChannel = try await NIOTSDatagramListenerBootstrap(group: group)
+                .childChannelInitializer { connectionChannel in
+                    connectionChannel.eventLoop.makeCompletedFuture {
+                        try connectionChannel.pipeline.syncOperations.addHandler(waitForConnectionHandler)
+                    }
                 }
-            }
-            .configureNWParameters { _ in
-                configuratorListenerCounter.withLockedValue { $0 += 1 }
-            }
-            .bind(host: "localhost", port: 0)
-            .get()
+                .configureNWParameters { _ in
+                    configuratorListenerCounter.withLockedValue { $0 += 1 }
+                }
+                .bind(host: "localhost", port: 0)
+                .get()
 
-        let connectionChannel: Channel = try await NIOTSDatagramBootstrap(group: group)
-            .configureNWParameters { _ in
-                configuratorConnectionCounter.withLockedValue { $0 += 1 }
-            }
-            .connect(to: listenerChannel.localAddress!)
-            .get()
+            let connectionChannel: Channel = try await NIOTSDatagramBootstrap(group: group)
+                .configureNWParameters { _ in
+                    configuratorConnectionCounter.withLockedValue { $0 += 1 }
+                }
+                .connect(to: listenerChannel.localAddress!)
+                .get()
 
-        // Need to write something so the server can activate the connection channel: this is UDP,
-        // so there is no handshaking that happens and thus the server cannot know that the
-        // connection has been established and the channel can be activated.
-        try await connectionChannel.writeAndFlush(ByteBuffer(bytes: [42]))
+            // Need to write something so the server can activate the connection channel: this is UDP,
+            // so there is no handshaking that happens and thus the server cannot know that the
+            // connection has been established and the channel can be activated.
+            try await connectionChannel.writeAndFlush(ByteBuffer(bytes: [42]))
 
-        // Wait for the server to activate the connection channel to the client.
-        try await waitForConnectionHandler.connectionPromise.futureResult.get()
+            // Wait for the server to activate the connection channel to the client.
+            try await waitForConnectionHandler.connectionPromise.futureResult.get()
 
-        try await listenerChannel.close().get()
-        try await connectionChannel.close().get()
+            try await listenerChannel.close().get()
+            try await connectionChannel.close().get()
 
-        XCTAssertEqual(2, configuratorListenerCounter.withLockedValue { $0 })
-        XCTAssertEqual(1, configuratorConnectionCounter.withLockedValue { $0 })
-
-        try await group.shutdownGracefully()
+            XCTAssertEqual(2, configuratorListenerCounter.withLockedValue { $0 })
+            XCTAssertEqual(1, configuratorConnectionCounter.withLockedValue { $0 })
+        }
     }
 
     func testCanExtractTheConnection() throws {

--- a/Tests/NIOTransportServicesTests/NIOTSTestUtilities.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSTestUtilities.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Network)
 import NIOCore
 import NIOTransportServices
 
@@ -24,3 +25,19 @@ func withEventLoopGroup(_ test: (EventLoopGroup) async throws -> Void) async ret
         throw error
     }
 }
+
+final class WaitForConnectionHandler: ChannelInboundHandler, Sendable {
+    typealias InboundIn = Never
+
+    let connectionPromise: EventLoopPromise<Void>
+
+    init(connectionPromise: EventLoopPromise<Void>) {
+        self.connectionPromise = connectionPromise
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        self.connectionPromise.succeed()
+        context.fireChannelActive()
+    }
+}
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSTestUtilities.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSTestUtilities.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOTransportServices
+
+func withEventLoopGroup(_ test: (EventLoopGroup) async throws -> Void) async rethrows {
+    let group = NIOTSEventLoopGroup()
+    do {
+        try await test(group)
+    } catch {
+        try await group.shutdownGracefully()
+        throw error
+    }
+}

--- a/Tests/NIOTransportServicesTests/NIOTSTestUtilities.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSTestUtilities.swift
@@ -20,8 +20,9 @@ func withEventLoopGroup(_ test: (EventLoopGroup) async throws -> Void) async ret
     let group = NIOTSEventLoopGroup()
     do {
         try await test(group)
+        try? await group.shutdownGracefully()
     } catch {
-        try await group.shutdownGracefully()
+        try? await group.shutdownGracefully()
         throw error
     }
 }


### PR DESCRIPTION
Allow users to provide a closure taking an `NWParameters` to customise them before they're used to create `NWConnection`s.

### Motivation:

`NWParameters` are currently created using the provided TLS and UDP options, and then passed over to new `NWConnection`s. However, there are more ways in which `NWParameters` can be customised, so this new API provides a way for users to do this.

### Modifications:

Introduce new `configureNWParameters` methods to the existing bootstraps to allow configuring a closure for customising `NWParameters`.

### Result:

Users can now customise the `NWParameters` used to create new `NWConnection`s.