### PR TITLE
Fix missing strict concurrency error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let strictConcurrencySettings: [SwiftSetting] = {
     if strictConcurrencyDevelopment {
         // -warnings-as-errors here is a workaround so that IDE-based development can
         // get tripped up on -require-explicit-sendable.
-        initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
+        initialSettings.append(.unsafeFlags(["-Xfrontend", "-require-explicit-sendable", "-warnings-as-errors"]))
     }
 
     return initialSettings

--- a/Sources/NIOTransportServices/NIOTSErrors.swift
+++ b/Sources/NIOTransportServices/NIOTSErrors.swift
@@ -21,7 +21,7 @@ import NIOCore
 public protocol NIOTSError: Error, Equatable {}
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
-public enum NIOTSErrors {
+public enum NIOTSErrors: Sendable {
     /// ``InvalidChannelStateTransition`` is thrown when a channel has been asked to do something
     /// that is incompatible with its current channel state: e.g. attempting to register an
     /// already registered channel.


### PR DESCRIPTION
Current strict concurrency checks don't work consistently in Xcode. This PR adds an additional flag (`-Xfrontend`) to our set of strict concurrency flags to make sure nothing has been missed when building. It also fixes an additional error uncovered after adding it.