### PR TITLE
`NIOTSEventLoop` conforms to `NIOSerialEventLoopExecutor`

### DIFF
--- a/Sources/NIOTransportServices/NIOTSEventLoop.swift
+++ b/Sources/NIOTransportServices/NIOTSEventLoop.swift
@@ -298,4 +298,8 @@ extension NIOTSEventLoop {
         assert(oldChannel != nil)
     }
 }
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension NIOTSEventLoop: NIOSerialEventLoopExecutor {}
+
 #endif


### PR DESCRIPTION
Every EventLoop can also be a SerialExecutor. Let's opt into the default NIO fast-path implementation.

SemVer patch as NIOTSEventLoop isn't public API.