### PR TITLE
Fix receiving more than 1 blob of data on a NWConnection

### DIFF
--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramConnectionChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramConnectionChannel.swift
@@ -69,6 +69,9 @@ internal final class NIOTSDatagramConnectionChannel: StateManagedNWConnectionCha
     /// The underlying `NWConnection` that this `Channel` wraps. This is only non-nil
     /// after the initial connection attempt has been made.
     internal var connection: NWConnection?
+    
+    /// `isComplete` on a NWConnection's `receive` callback indicates the datagram has been fully received
+    var completionClosesChannel: Bool { false }
 
     /// The minimum length of data to receive from this connection, until the content is complete.
     internal var minimumIncompleteReceiveLength: Int

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -151,6 +151,9 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
     /// The underlying `NWConnection` that this `Channel` wraps. This is only non-nil
     /// after the initial connection attempt has been made.
     internal var connection: NWConnection?
+    
+    /// `isComplete` on a NWConnection's `receive` callback indicates the socket has closed
+    internal var completionClosesChannel: Bool { true }
 
     /// The minimum length of data to receive from this connection, until the content is complete.
     internal var minimumIncompleteReceiveLength: Int


### PR DESCRIPTION
Prevent closing the channel on `isFinished` for a datagram message

### Motivation:

NWConnection for UDP currently closes too soon, it closes after 1 completed read.

### Modifications:

Don't close the connection on UDP read.