### PR TITLE
Fixes premature closure of NIOTS UDP channels by not treating per-datagram isComplete as EOF.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,6 +76,7 @@ let package = Package(
                 "NIOTransportServices",
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ],
             swiftSettings: strictConcurrencySettings

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2025 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -68,6 +68,13 @@ let package = Package(
                 "NIOTransportServices",
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+            ]
+        ),
+        .executableTarget(
+            name: "NIOTSEchoClient",
+            dependencies: [
+                "NIOTransportServices",
+                .product(name: "NIOCore", package: "swift-nio"),
             ]
         ),
         .testTarget(

--- a/Sources/NIOTSEchoClient/NIOTSEchoClient.swift
+++ b/Sources/NIOTSEchoClient/NIOTSEchoClient.swift
@@ -31,21 +31,21 @@ import Darwin
 final class EchoHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
-    
+
     func channelActive(context: ChannelHandlerContext) {
         print("Channel active")
     }
-    
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         var buf = self.unwrapInboundIn(data)
         let text = buf.readString(length: buf.readableBytes) ?? "<\(buf.readableBytes) bytes>"
         print("echo:", text)
     }
-    
+
     func channelInactive(context: ChannelHandlerContext) {
         print("Channel inactive (closed)")
     }
-    
+
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         print("error:", error)
         // Intentionally do not close here; keep running to observe behavior.

--- a/Sources/NIOTSEchoClient/NIOTSEchoClient.swift
+++ b/Sources/NIOTSEchoClient/NIOTSEchoClient.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the NIOTSEchoClient open source project
+// This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2025 Route Objects and the NIOTSEchoClient project authors
+// Copyright (c) 2017-2025 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of NIOTSEchoClient project authors
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -27,7 +27,7 @@ import NIOCore
 import NIOTransportServices
 import Darwin
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 final class EchoHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer

--- a/Sources/NIOTSEchoClient/NIOTSEchoClient.swift
+++ b/Sources/NIOTSEchoClient/NIOTSEchoClient.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the NIOTSEchoClient open source project
+//
+// Copyright (c) 2025 Route Objects and the NIOTSEchoClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of NIOTSEchoClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Build/Run (from repo root):
+//   cd swift-nio-transport-services
+//   swift run NIOTSEchoClient 127.0.0.1 9999
+//
+// Server: use SwiftNIO's UDP echo server (NIOUDPEchoServer).
+// In a SwiftNIO checkout that contains Sources/NIOUDPEchoServer, run:
+//   swift run NIOUDPEchoServer 127.0.0.1 9999
+//
+
+#if canImport(Network)
+
+import NIOCore
+import NIOTransportServices
+import Darwin
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+final class EchoHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+    
+    func channelActive(context: ChannelHandlerContext) {
+        print("Channel active")
+    }
+    
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buf = self.unwrapInboundIn(data)
+        let text = buf.readString(length: buf.readableBytes) ?? "<\(buf.readableBytes) bytes>"
+        print("echo:", text)
+    }
+    
+    func channelInactive(context: ChannelHandlerContext) {
+        print("Channel inactive (closed)")
+    }
+    
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        print("error:", error)
+        // Intentionally do not close here; keep running to observe behavior.
+    }
+}
+
+@main
+struct NIOTSEchoClient {
+    static func main() throws {
+        if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+            let args = CommandLine.arguments
+            let host = args.count > 1 ? args[1] : "127.0.0.1"
+            let port = (args.count > 2 ? Int(args[2]) : nil) ?? 9999
+
+            let group = NIOTSEventLoopGroup(loopCount: 1)
+
+            // Use the connected-UDP bootstrap (aka NIOTSDatagramBootstrap via typealias).
+            let bootstrap = NIOTSDatagramConnectionBootstrap(group: group)
+                .channelInitializer { channel in
+                    channel.pipeline.addHandler(EchoHandler())
+                }
+
+            let channel = try bootstrap.connect(host: host, port: port).wait()
+            print("Connected to \(host):\(port) — start typing. Ctrl-C to exit.")
+
+            // If the channel closes (remote or local), shut down the group and exit.
+            channel.closeFuture.whenComplete { _ in
+                // Best-effort shutdown and process exit for a CLI.
+                _ = try? group.syncShutdownGracefully()
+                // Exit the process to stop stdin loop if still running.
+                exit(0)
+            }
+
+            // Read lines from stdin and send each line as a datagram.
+            while let line = readLine(strippingNewline: true) {
+                channel.eventLoop.execute {
+                    var buf = channel.allocator.buffer(capacity: line.utf8.count)
+                    buf.writeString(line)
+                    channel.writeAndFlush(buf).whenFailure { error in
+                        print("write failed:", error)
+                    }
+                }
+            }
+
+            // Optional graceful shutdown on EOF (Ctrl-D). Ctrl-C will terminate the process.
+            _ = try? channel.close().wait()
+            try? group.syncShutdownGracefully()
+        } else {
+            print("NIOTSEchoClient requires macOS 10.14+, iOS 12+, tvOS 12+ and watchOS 6+.")
+        }
+    }
+}
+
+#else
+
+@main
+struct NIOTSEchoClientUnsupportedPlatform {
+    static func main() {
+        print("NIOTSEchoClient requires Network.framework (Apple platforms). On Linux, use swift-nio UDP instead.")
+    }
+}
+
+#endif

--- a/Sources/NIOTransportServices/Datagram/NIOTSDatagramConnectionChannel.swift
+++ b/Sources/NIOTransportServices/Datagram/NIOTSDatagramConnectionChannel.swift
@@ -148,6 +148,9 @@ internal final class NIOTSDatagramConnectionChannel: StateManagedNWConnectionCha
         return parameters
     }
 
+    // This channel carries datagrams (UDP), not a byte stream.
+    internal var isDatagramChannel: Bool { true }
+
     var _inboundStreamOpen: Bool {
         switch self.state {
         case .active(.open):

--- a/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionBootstrap.swift
@@ -241,10 +241,11 @@ public final class NIOTSConnectionBootstrap {
     private func connect(
         existingNWConnection: NWConnection? = nil,
         shouldRegister: Bool,
-        _ connectAction: @Sendable @escaping (
-            NIOTSConnectionChannel,
-            EventLoopPromise<Void>
-        ) -> Void
+        _ connectAction:
+            @Sendable @escaping (
+                NIOTSConnectionChannel,
+                EventLoopPromise<Void>
+            ) -> Void
     ) -> EventLoopFuture<Channel> {
         let conn: NIOTSConnectionChannel
         if let newConnection = existingNWConnection {

--- a/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
@@ -457,11 +457,9 @@ extension StateManagedNWConnectionChannel {
         if let error = error {
             self.pipeline.fireErrorCaught(error)
             self.close0(error: error, mode: .all, promise: nil)
-        } else if isComplete {
+        } else if isComplete && !self.isDatagramChannel {
             // Only streams should translate `isComplete` into EOF. For datagrams, continue receiving.
-            if !self.isDatagramChannel {
-                self.didReadEOF()
-            }
+            self.didReadEOF()
         }
 
         // Last, issue a new read automatically if we need to.

--- a/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
@@ -85,6 +85,10 @@ internal protocol StateManagedNWConnectionChannel: StateManagedChannel where Act
 
     var nwParametersConfigurator: (@Sendable (NWParameters) -> Void)? { get }
 
+    /// Indicates whether this connection channel carries datagrams (UDP) rather than a byte stream (TCP/TLS).
+    /// Defaults to `false` and is overridden by datagram-specific channel implementations.
+    var isDatagramChannel: Bool { get }
+
     func setChannelSpecificOption0<Option: ChannelOption>(option: Option, value: Option.Value) throws
 
     func getChannelSpecificOption0<Option: ChannelOption>(option: Option) throws -> Option.Value
@@ -99,6 +103,8 @@ extension StateManagedNWConnectionChannel {
     public var _channelCore: ChannelCore {
         self
     }
+
+    public var isDatagramChannel: Bool { false }
 
     /// The local address for this channel.
     public var localAddress: SocketAddress? {
@@ -443,11 +449,19 @@ extension StateManagedNWConnectionChannel {
 
         // Next, we want to check if there's an error. If there is, we're going to deliver it, and then close the connection with
         // it. Otherwise, we're going to check if we read EOF, and if we did we'll close with that instead.
+        //
+        // Important: For datagram (UDP) connections, Network.framework reports `isComplete == true` for each
+        // received datagram. This does NOT indicate stream EOF. Treating it as EOF closes the connected UDP
+        // channel after the first packet ("one‑shot"). Guard against this by only considering `isComplete`
+        // a real EOF on non-datagram (stream) channels.
         if let error = error {
             self.pipeline.fireErrorCaught(error)
             self.close0(error: error, mode: .all, promise: nil)
         } else if isComplete {
-            self.didReadEOF()
+            // Only streams should translate `isComplete` into EOF. For datagrams, continue receiving.
+            if !self.isDatagramChannel {
+                self.didReadEOF()
+            }
         }
 
         // Last, issue a new read automatically if we need to.

--- a/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
+++ b/Sources/NIOTransportServices/StateManagedNWConnectionChannel.swift
@@ -104,7 +104,7 @@ extension StateManagedNWConnectionChannel {
         self
     }
 
-    public var isDatagramChannel: Bool { false }
+    internal var isDatagramChannel: Bool { false }
 
     /// The local address for this channel.
     public var localAddress: SocketAddress? {

--- a/Tests/NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.swift
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+// This test isolates a NIOTS UDP client talking to a POSIX UDP echo server.
+// It sends two datagrams: "hello" and "world". The first echo is asserted
+// strictly. The second echo is wrapped in XCTExpectFailure to expose the
+// suspected NIOTS "one‑shot" close/drop after the first round‑trip.
+//===----------------------------------------------------------------------===//
+
+//    How to run just this test
+//
+//    - From the swift-nio-transport-services repo root:
+//    - swift test -v --filter NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.testNIOTSClient_POSIXServer_MultipleDatagrams_expectedFailure
+
+
+#if canImport(Network)
+import XCTest
+import NIOCore
+import NIOPosix
+import NIOTransportServices
+
+private final class POSIXUDPEchoHandler: ChannelInboundHandler {
+    typealias InboundIn = AddressedEnvelope<ByteBuffer>
+    typealias OutboundOut = AddressedEnvelope<ByteBuffer>
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let envelope = self.unwrapInboundIn(data)
+        context.write(self.wrapOutboundOut(envelope), promise: nil)
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        context.flush()
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        // Keep the server simple; close on error
+        context.close(promise: nil)
+    }
+}
+
+private final class ClientCaptureHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let onRead: (String) -> Void
+    init(onRead: @escaping (String) -> Void) { self.onRead = onRead }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buf = self.unwrapInboundIn(data)
+        let s = buf.readString(length: buf.readableBytes) ?? ""
+        // print("[client] read:", s)
+        self.onRead(s)
+    }
+}
+
+// Debug probe (disabled for upstream submission)
+// private final class LifecycleProbeHandler: ChannelInboundHandler {
+//     typealias InboundIn = Any
+//     private let tag: String
+//     init(tag: String) { self.tag = tag }
+//     func handlerAdded(context: ChannelHandlerContext) { print("[\(tag)] handlerAdded") }
+//     func channelActive(context: ChannelHandlerContext) { print("[\(tag)] channelActive"); context.fireChannelActive() }
+//     func channelInactive(context: ChannelHandlerContext) { print("[\(tag)] channelInactive"); context.fireChannelInactive() }
+//     func errorCaught(context: ChannelHandlerContext, error: Error) { print("[\(tag)] errorCaught: \(error)"); context.fireErrorCaught(error) }
+// }
+
+private final class UDPClientActiveHandler: ChannelInboundHandler {
+    typealias InboundIn = Any
+    private let activePromise: EventLoopPromise<Void>
+    init(_ p: EventLoopPromise<Void>) { self.activePromise = p }
+    func channelActive(context: ChannelHandlerContext) {
+        self.activePromise.succeed(())
+        context.fireChannelActive()
+    }
+}
+
+final class NIOTSUDPMultiDatagramsPOSIXServerTests: XCTestCase {
+    // Reproducer for suspected NIOTS connected‑UDP “one‑shot” close.
+    // After the first datagram round‑trip, the NIOTS datagram channel may close,
+    // causing subsequent datagrams to fail or never be echoed. This test uses a
+    // stable POSIX UDP echo server and a NIOTS UDP client to isolate the issue.
+    //
+    // How to run only this test:
+    // swift test -v --filter NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.testNIOTSClient_POSIXServer_MultipleDatagrams_expectedFailure
+    //
+    // Expected behavior:
+    // - First echo ("hello") succeeds.
+    // - Second echo ("world") times out; wrapped in XCTExpectFailure so CI stays green.
+    //
+    // Xcode (symbolic breakpoint)
+    //
+    // - Open the Breakpoint Navigator.
+    // - Click + → Add Symbolic Breakpoint…
+    // - Symbol: nw_connection_cancel
+    // - (Optional) Add Action: debugger command bt
+    // - Run your test; Xcode will break when NIOTS cancels the NWConnection.
+    //
+    // Optional LLDB steps (Xcode):
+    // 1) Add a Symbolic Breakpoint: br s -n nw_connection_cancel
+    // 2) Run this test; when it breaks, run `bt` in the debugger.
+    // 3) Typical call chain observed after the first echoed datagram:
+    //
+    //    StateManagedNWConnectionChannel.dataReceivedHandler(content=<N bytes>, isComplete=true, error=nil)
+    //    → didReadEOF()
+    //    → StateManagedChannel.close0(error=eof)
+    //    → nw_connection_cancel
+    //
+    //    Note error=nil: the close is triggered solely because isComplete was true.
+    func testNIOTSClient_POSIXServer_MultipleDatagrams_expectedFailure() throws {
+        // POSIX UDP echo server
+        let serverGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try serverGroup.syncShutdownGracefully()) }
+
+        let server = try DatagramBootstrap(group: serverGroup)
+            .channelOption(.socketOption(.so_reuseaddr), value: 1)
+            .channelInitializer { ch in
+                ch.eventLoop.makeCompletedFuture {
+                    try ch.pipeline.syncOperations.addHandler(POSIXUDPEchoHandler())
+                }
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+        defer { XCTAssertNoThrow(try server.close().wait()) }
+
+        guard let port = server.localAddress?.port else {
+            XCTFail("No server port")
+            return
+        }
+
+        // NIOTS connected UDP client
+        let clientGroup = NIOTSEventLoopGroup(loopCount: 1)
+        defer { XCTAssertNoThrow(try clientGroup.syncShutdownGracefully()) }
+
+        let gotHello = expectation(description: "got hello")
+        let gotWorld = expectation(description: "got world")
+
+        let clientActive = clientGroup.next().makePromise(of: Void.self)
+        let client = try NIOTSDatagramConnectionBootstrap(group: clientGroup)
+            .channelInitializer { ch in
+                ch.eventLoop.makeCompletedFuture {
+                    // Debug probe disabled to keep the test minimal for upstream submission.
+                    // try ch.pipeline.syncOperations.addHandler(LifecycleProbeHandler(tag: "client"))
+                    try ch.pipeline.syncOperations.addHandler(UDPClientActiveHandler(clientActive))
+                    try ch.pipeline.syncOperations.addHandler(ClientCaptureHandler { text in
+                        if text == "hello" { gotHello.fulfill() }
+                        if text == "world" { gotWorld.fulfill() }
+                    })
+                }
+            }
+            .connect(host: "127.0.0.1", port: port)
+            .wait()
+        
+        defer { _ = try? client.close().wait() }
+
+        // Avoid early write before active
+        XCTAssertNoThrow(try clientActive.futureResult.wait())
+
+        // First datagram: expect echo strictly
+        var hello = client.allocator.buffer(capacity: 5); hello.writeString("hello")
+        XCTAssertNoThrow(try client.writeAndFlush(hello).wait())
+        wait(for: [gotHello], timeout: 1.0)
+
+        // Second datagram: expose suspected NIOTS one‑shot behavior
+        var world = client.allocator.buffer(capacity: 5); world.writeString("world")
+        XCTExpectFailure("NIOTS may close connected UDP after first datagram (one‑shot). Second echo may be lost. Tracking: https://github.com/apple/swift-nio-transport-services/issues/XXXX") {
+            _ = try? client.writeAndFlush(world).wait()
+            wait(for: [gotWorld], timeout: 0.75)
+        }
+    }
+}
+#endif

--- a/Tests/NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.swift
@@ -23,7 +23,6 @@
 //    - From the swift-nio-transport-services repo root:
 //    - swift test -v --filter NIOTransportServicesTests/NIOTSUDPMultiDatagramsPOSIXServerTests.testNIOTSClient_POSIXServer_MultipleDatagrams
 
-
 #if canImport(Network)
 import XCTest
 import NIOCore
@@ -107,15 +106,17 @@ final class NIOTSUDPMultiDatagramsPOSIXServerTests: XCTestCase {
             .channelInitializer { ch in
                 ch.eventLoop.makeCompletedFuture {
                     try ch.pipeline.syncOperations.addHandler(UDPClientActiveHandler(clientActive))
-                    try ch.pipeline.syncOperations.addHandler(ClientCaptureHandler { text in
-                        if text == "hello" { gotHello.fulfill() }
-                        if text == "world" { gotWorld.fulfill() }
-                    })
+                    try ch.pipeline.syncOperations.addHandler(
+                        ClientCaptureHandler { text in
+                            if text == "hello" { gotHello.fulfill() }
+                            if text == "world" { gotWorld.fulfill() }
+                        }
+                    )
                 }
             }
             .connect(host: "127.0.0.1", port: port)
             .wait()
-        
+
         defer { XCTAssertNoThrow(try client.close().wait()) }
 
         // Avoid early write before active


### PR DESCRIPTION
 Fix NIOTS UDP premature close by not treating per‑datagram isComplete as EOF; add multi‑datagram tests and NIOTSEchoClient example.

  Motivation:

  - While using [DNSClient #40](https://github.com/orlandos-nl/DNSClient/issues/40), we observed “one‑shot” behavior: a NIOTS connected‑UDP channel closed after the first datagram, causing subsequent writes to fail or be dropped.
  - Network.framework sets isComplete == true for each UDP datagram. This indicates message completeness, not stream EOF. Treating that signal as EOF caused the early close.
  - [PR#243](https://github.com/apple/swift-nio-transport-services/pull/243) explored gating behavior differently (e.g., via “completionClosesChannel”). This PR aligns EOF handling explicitly to channel semantics (stream vs. datagram), which makes the reasoning around transport semantics clear.
  - Alternatives considered (brief):
      - ContentContext.isFinal only: common stream half‑closes (FIN) arrive with isComplete == true and isFinal == false, so relying solely on isFinal would miss EOF on streams and risk hangs.
      - protocolMetadata (e.g., NWProtocolUDP.Metadata): metadata presence/shape varies and is often empty on final callbacks; channel semantics (isDatagramChannel) are explicit and robust.
  - Reproducer (pre‑fix): set a symbolic breakpoint `br s -n nw_connection_cancel`; run `testBasicChannelCommunication()` test; typical backtrace after the echoed datagram:
      - StateManagedNWConnectionChannel.dataReceivedHandler(content=<N bytes>, isComplete=true, error=nil) → didReadEOF() → StateManagedChannel.close0(error=eof) → nw_connection_cancel.
      - Note error=nil: close was triggered solely because isComplete was true.

  Modifications:

  - Transport fix:
      - StateManagedNWConnectionChannel.dataReceivedHandler now calls didReadEOF() only when isComplete && !isDatagramChannel (streams unchanged; datagrams no longer misinterpret isComplete as EOF).
  - Tests:
      - NIOTSDatagramBootstrapTests.testConnectedUDPEchoesTwoDatagrams verifies two echoes on NIOTS connected UDP; both server and client observe datagrams; bounded timeouts; proper cleanup.
      - NIOTSUDPMultiDatagramsPOSIXServerTests.testNIOTSClient_POSIXServer_MultipleDatagrams verifies NIOTS client ↔ POSIX UDP echo; asserts two echoes to isolate cross‑stack behavior.
  - Example:
      - NIOTSEchoClient executable example (Apple platforms): simple connected‑UDP echo client using NIOTSDatagramConnectionBootstrap; guarded with `canImport(Network)` and `@available`; minimal usage notes.

  Result:

  - Datagram channels (UDP) no longer misinterpret per‑packet completeness as EOF; multi‑datagram send/receive works as expected.
  - Stream channels (TCP/TLS) are unchanged; EOF continues to be detected per existing behavior.
  - Restores expected behavior so typical NIO UDP apps can be ported to NIOTS by swapping event loops and datagram bootstraps (on Apple platforms using Network.framework).
  - Manual validation available via NIOTSEchoClient (pair with SwiftNIO’s NIOUDPEchoServer).
