### PR TITLE
Only depend on NIOFoundationCompat on Apple platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,11 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: applePlatforms)),
+                .product(
+                    name: "NIOFoundationCompat",
+                    package: "swift-nio",
+                    condition: .when(platforms: applePlatforms)
+                ),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,8 @@
 
 import PackageDescription
 
+let applePlatforms: [Platform] = [.iOS, .macOS, .tvOS, .watchOS, .macCatalyst, .driverKit, .visionOS]
+
 let strictConcurrencyDevelopment = false
 
 let strictConcurrencySettings: [SwiftSetting] = {
@@ -44,7 +46,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: applePlatforms)),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
             ],


### PR DESCRIPTION
Only depend on NIOFoundationCompat on Apple platforms

### Motivation:

https://github.com/apple/swift-nio-transport-services/pull/211#issuecomment-4170778092

### Modifications:

Only depend on NIOFoundationCompat on Apple platforms because it's only imported when Network can also be imported, so we don't unnecessarily depend transitively on Foundation.

(We should use anyAppleOS as the condition if/when it becomes available in SPM too: https://forums.swift.org/t/introducing-anyappleos/85728 )

### Result:

Stripped release binary is 20MB instead of 65MB in a project using mqtt-nio
