### PR TITLE
Delete UNIX domain socket file after testBasicUnixSockets

### DIFF
--- a/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
+++ b/Tests/NIOTransportServicesTests/NIOTSEndToEndTests.swift
@@ -494,6 +494,9 @@ class NIOTSEndToEndTests: XCTestCase {
         // sockaddr_un cannot hold paths as long as the true temporary directories used by
         // FileManager.
         let udsPath = "/tmp/\(UUID().uuidString)_testBasicUnixSockets.sock"
+        defer {
+            try? FileManager.default.removeItem(atPath: udsPath)
+        }
 
         let listener = try NIOTSListenerBootstrap(group: self.group)
             .childChannelInitializer { channel in


### PR DESCRIPTION
## Motivation

`testBasicUnixSockets` binds a listener to a UNIX domain socket file under `/tmp` (e.g. `/tmp/<uuid>_testBasicUnixSockets.sock`) but never removes that file once the test finishes. Each run therefore leaves a stale socket file behind, slowly littering `/tmp` on every test invocation.

Fixes #53.

## Modifications

Added a `defer` block immediately after the socket path is computed that removes the file with `FileManager.default.removeItem(atPath:)`. Because `defer` blocks execute in LIFO order, this cleanup runs after the existing `listener.close()`/`connection.close()` deferred closures, so the socket is closed before the backing file is deleted. The removal is best-effort (`try?`) so it never masks a genuine test failure.

## Result

`testBasicUnixSockets` no longer leaves a socket file in `/tmp` after running. No behavioral change to the test's assertions.

Verified locally:
- `swift build` — Build complete.
- `swift test --filter NIOTSEndToEndTests/testBasicUnixSockets` — 1 test, 0 failures.
- Confirmed no `*_testBasicUnixSockets.sock` files remain in `/tmp` after the run.
